### PR TITLE
Add parsing of single quoted strings

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1826,7 +1826,9 @@ impl Parser {
                 is_escaped = false;
             } else if self.compiler.source[span_position] == b'\\' {
                 is_escaped = true;
-            } else if self.compiler.source[span_position] == b'"' {
+            } else if self.compiler.source[span_position] == b'"'
+                || self.compiler.source[span_position] == b'\''
+            {
                 span_position += 1;
                 break;
             }
@@ -2381,22 +2383,22 @@ impl Parser {
         loop {
             if self.span_offset >= self.compiler.source.len() {
                 return None;
-            } else if self.compiler.source[self.span_offset].is_ascii_digit() {
+            }
+
+            let char = self.compiler.source[self.span_offset];
+
+            if char.is_ascii_digit() {
                 return self.lex_number();
-            } else if self.compiler.source[self.span_offset] == b'"' {
+            } else if char == b'"' || char == b'\'' {
                 return self.lex_quoted_string();
-            } else if self.compiler.source[self.span_offset] == b'#' {
+            } else if char == b'#' {
                 // Comment
                 self.skip_comment();
             } else if is_symbol(&self.compiler.source[self.span_offset..]) {
                 return self.lex_symbol();
-            } else if self.compiler.source[self.span_offset] == b' '
-                || self.compiler.source[self.span_offset] == b'\t'
-            {
+            } else if char == b' ' || char == b'\t' {
                 self.skip_space()
-            } else if self.compiler.source[self.span_offset] == b'\r'
-                || self.compiler.source[self.span_offset] == b'\n'
-            {
+            } else if char == b'\r' || char == b'\n' {
                 return self.newline();
             } else {
                 return self.lex_name();

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -5,10 +5,11 @@ input_file: tests/string.nu
 ---
 ==== COMPILER ====
 0: String (0 to 13)
-1: Block(BlockId(0)) (0 to 13)
+1: String (14 to 27)
+2: Block(BlockId(0)) (0 to 27)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(1)
+0: Frame Scope, variables: [  ], node_id: NodeId(2)
 ==== TYPES ====
 0: string
-1: ()
-
+1: string
+2: ()

--- a/tests/string.nu
+++ b/tests/string.nu
@@ -1,1 +1,2 @@
 "hello world"
+'hello world'


### PR DESCRIPTION
Single quotes can now create strings, like double quotes. There is no distinction between the two yet.