### PR TITLE
Start calls

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -96,6 +96,7 @@ impl Compiler {
 
     #[allow(clippy::format_collect)]
     pub fn display_state(&self) -> String {
+        // TODO: This should say PARSER, not COMPILER
         let mut result = "==== COMPILER ====\n".to_string();
 
         for (idx, ast_node) in self.ast_nodes.iter().enumerate() {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -200,4 +200,11 @@ impl Compiler {
             .get(span.start..span.end)
             .expect("internal error: missing source of span")
     }
+
+    /// Get the source contents of a span
+    pub fn get_span_contents_manual(&self, span_start: usize, span_end: usize) -> &[u8] {
+        self.source
+            .get(span_start..span_end)
+            .expect("internal error: missing source of span")
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod compiler;
 pub mod errors;
+pub mod naming;
 pub mod parser;
 pub mod protocol;
 pub mod resolver;

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,0 +1,33 @@
+//! Naming is hard
+//!
+//! The intent for this file is to store all naming-related code in one place.
+
+pub const STRING_STRICT: BarewordContext = BarewordContext {
+    as_string: true,
+    strictness: NameStrictness::Strict,
+};
+
+pub const NAME_STRICT: BarewordContext = BarewordContext {
+    as_string: false,
+    strictness: NameStrictness::Strict,
+};
+
+/// Defines how barewords should be handled when parsing expressions
+#[derive(Debug, Copy, Clone)]
+pub struct BarewordContext {
+    /// Bareword is a string (e.g., in `[ a b c ]`)
+    pub as_string: bool,
+    /// Which characters are allowed / forbidden for the bareeword
+    pub strictness: NameStrictness,
+}
+
+/// Defines which characters are allowed for names and barewords
+///
+/// All of thee variants disallow whitespace
+#[derive(Debug, Copy, Clone)]
+pub enum NameStrictness {
+    /// Only letters and '_' are allowed (no punctuation)
+    Strict,
+    /// All characters except those in the list are allowed
+    AllCharsExcept(&'static [u8]),
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -250,6 +250,9 @@ impl Parser {
         } else if self.is_keyword(b"match") {
             return self.match_expression();
         }
+        // TODO
+        // } else if self.is_keyword(b"where") {
+        // }
 
         // Otherwise assume a math expression
         let mut leftmost = self.simple_expression();
@@ -1580,7 +1583,10 @@ impl Parser {
     }
 
     pub fn is_expression(&mut self) -> bool {
-        self.is_simple_expression() || self.is_keyword(b"if") || self.is_keyword(b"where")
+        self.is_simple_expression()
+            || self.is_keyword(b"if")
+            || self.is_keyword(b"match")
+            || self.is_keyword(b"where")
     }
 
     pub fn is_simple_expression(&mut self) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -762,6 +762,23 @@ impl Parser {
                     self.next();
                     self.create_node(AstNode::DivideAssignment, span_start, span_end)
                 }
+                TokenType::Name => {
+                    let op = &self.compiler.source[span_start..span_end];
+                    match op {
+                        b"and" => {
+                            self.next();
+                            self.create_node(AstNode::And, span_start, span_end)
+                        }
+                        b"or" => {
+                            self.next();
+                            self.create_node(AstNode::Or, span_start, span_end)
+                        }
+                        _ => self.error(format!(
+                            "Unknown operator: '{}'",
+                            String::from_utf8_lossy(op)
+                        )),
+                    }
+                }
                 _ => self.error("expected: operator"),
             },
             _ => self.error("expected: operator"),
@@ -1303,6 +1320,14 @@ impl Parser {
 
     pub fn is_operator(&mut self) -> bool {
         match self.peek() {
+            Some(Token {
+                token_type: TokenType::Name,
+                span_start,
+                span_end,
+            }) => {
+                &self.compiler.source[span_start..span_end] == b"and"
+                    || &self.compiler.source[span_start..span_end] == b"or"
+            }
             Some(Token { token_type, .. }) => matches!(
                 token_type,
                 TokenType::Asterisk

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -375,7 +375,7 @@ impl Parser {
         } else if self.is_dollar() {
             self.variable()
         } else if self.is_name() {
-            self.name()
+            self.call()
         } else {
             self.error("incomplete expression")
         };
@@ -534,6 +534,24 @@ impl Parser {
         } else {
             self.error("expected variable")
         }
+    }
+
+    pub fn call(&mut self) -> NodeId {
+        let head = self.name();
+        // let mut args = vec![];
+        // let span_start = self.position();
+
+        // while self.has_tokens() {
+        //     if self.is_newline() {
+        //         break;
+        //     }
+        //     args.push(self.name());
+        // }
+
+        // let span_end = self.position();
+
+        // self.create_node(AstNode::Call { head, args }, span_start, span_end)
+        head
     }
 
     pub fn list_or_table(&mut self) -> NodeId {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -561,6 +561,8 @@ impl Parser {
                 continue;
             }
 
+            // TODO: Add flags
+
             is_head = false;
             let id = self.simple_expression(true);
             let span = self.compiler.spans[id.0];

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,6 +44,7 @@ pub enum ParamsContext {
     Pipes,
 }
 
+// TODO: All nodes with Vec<...> should be moved to their own ID (like BlockId) to allow Copy trait
 #[derive(Debug, PartialEq, Clone)]
 pub enum AstNode {
     Int,
@@ -130,6 +131,7 @@ pub enum AstNode {
     },
 
     // Expressions
+    // TODO: Call if the largest now (56 bytes)
     Call {
         head: Vec<NodeId>,
         args: Vec<NodeId>,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -199,6 +199,7 @@ impl<'a> Resolver<'a> {
     pub fn resolve_node(&mut self, node_id: NodeId) {
         match self.compiler.ast_nodes[node_id.0] {
             AstNode::Variable => self.resolve_variable(node_id),
+            AstNode::Call { ref head, ref args } => self.resolve_call(node_id, head, args),
             AstNode::Block(block_id) => self.resolve_block(node_id, block_id, None),
             AstNode::Closure { params, block } => {
                 // making sure the closure parameters and body end up in the same scope frame
@@ -279,11 +280,6 @@ impl<'a> Resolver<'a> {
             AstNode::Loop { block } => {
                 self.resolve_node(block);
             }
-            AstNode::Call { head: _, ref args } => {
-                for arg in args {
-                    self.resolve_node(*arg);
-                }
-            }
             AstNode::BinaryOp { lhs, op: _, rhs } => {
                 self.resolve_node(lhs);
                 self.resolve_node(rhs);
@@ -359,6 +355,35 @@ impl<'a> Resolver<'a> {
                 node_id: unbound_node_id,
                 severity: Severity::Error,
             })
+        }
+    }
+
+    pub fn resolve_call(&mut self, unbound_node_id: NodeId, head: &[NodeId], args: &[NodeId]) {
+        // Try to find the longest matching subcommand
+        let first_start = self.compiler.spans[head[0].0].start;
+
+        for n in (0..head.len()).rev() {
+            let last_end = self.compiler.spans[head[n].0].end;
+            let name = self
+                .compiler
+                .get_span_contents_manual(first_start, last_end);
+
+            if let Some(node_id) = self.find_decl(name) {
+                let decl_id = self
+                    .decl_resolution
+                    .get(&node_id)
+                    .expect("internal error: missing resolved decl");
+
+                self.decl_resolution.insert(unbound_node_id, *decl_id);
+                break;
+            }
+        }
+
+        // If the call does not correspond to any existing decl, it is an external call
+
+        // Resolve args
+        for arg in args {
+            self.resolve_node(*arg);
         }
     }
 
@@ -438,6 +463,7 @@ impl<'a> Resolver<'a> {
     }
 
     pub fn define_decl(&mut self, decl_name_id: NodeId) {
+        // TODO: Deduplicate code with define_variable()
         let decl_name = self.compiler.get_span_contents(decl_name_id);
         let decl_name = trim_decl_name(decl_name).to_vec();
         let decl = Declaration::new(String::from_utf8_lossy(&decl_name).to_string());
@@ -461,6 +487,17 @@ impl<'a> Resolver<'a> {
     pub fn find_variable(&self, var_name: &[u8]) -> Option<NodeId> {
         for scope_id in self.scope_stack.iter().rev() {
             if let Some(id) = self.scope[scope_id.0].variables.get(var_name) {
+                return Some(*id);
+            }
+        }
+
+        None
+    }
+
+    pub fn find_decl(&self, var_name: &[u8]) -> Option<NodeId> {
+        // TODO: Deduplicate code with find_variable()
+        for scope_id in self.scope_stack.iter().rev() {
+            if let Some(id) = self.scope[scope_id.0].decls.get(var_name) {
                 return Some(*id);
             }
         }

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
@@ -22,11 +22,12 @@ input_file: tests/binary_ops_exact.nu
 15: Float (35 to 38) "1.0"
 16: BinaryOp { lhs: NodeId(13), op: NodeId(14), rhs: NodeId(15) } (29 to 38)
 17: True (39 to 43)
-18: Name (44 to 47) "and"
+18: And (44 to 47)
 19: False (48 to 53)
-20: Block(BlockId(0)) (0 to 82)
+20: BinaryOp { lhs: NodeId(17), op: NodeId(18), rhs: NodeId(19) } (39 to 53)
+21: Block(BlockId(0)) (0 to 54)
 ==== SCOPE ====
-0: Frame Scope, node_id: NodeId(20) (empty)
+0: Frame Scope, node_id: NodeId(21) (empty)
 ==== TYPES ====
 0: int
 1: forbidden
@@ -46,8 +47,7 @@ input_file: tests/binary_ops_exact.nu
 15: float
 16: float
 17: bool
-18: unknown
+18: forbidden
 19: bool
-20: ()
-==== TYPE ERRORS ====
-Error (NodeId 18): unsupported ast node 'Name' in typechecker
+20: bool
+21: ()

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_mismatch.nu.snap
@@ -13,11 +13,12 @@ input_file: tests/binary_ops_mismatch.nu
 6: Float (17 to 20) "1.0"
 7: BinaryOp { lhs: NodeId(4), op: NodeId(5), rhs: NodeId(6) } (10 to 20)
 8: True (21 to 25)
-9: Name (26 to 29) "and"
+9: And (26 to 29)
 10: String (30 to 33) ""a""
-11: Block(BlockId(0)) (0 to 34)
+11: BinaryOp { lhs: NodeId(8), op: NodeId(9), rhs: NodeId(10) } (21 to 33)
+12: Block(BlockId(0)) (0 to 34)
 ==== SCOPE ====
-0: Frame Scope, node_id: NodeId(11) (empty)
+0: Frame Scope, node_id: NodeId(12) (empty)
 ==== TYPES ====
 0: string
 1: forbidden
@@ -28,10 +29,11 @@ input_file: tests/binary_ops_mismatch.nu
 6: float
 7: unknown
 8: bool
-9: unknown
+9: forbidden
 10: string
-11: ()
+11: unknown
+12: ()
 ==== TYPE ERRORS ====
 Error (NodeId 1): type mismatch: unsupported addition between string and float
 Error (NodeId 5): type mismatch: unsupported append between string and float
-Error (NodeId 9): unsupported ast node 'Name' in typechecker
+Error (NodeId 9): type mismatch: unsupported logical operation between bool and string

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -11,19 +11,17 @@ input_file: tests/calls.nu
 4: Plus (18 to 19)
 5: Int (20 to 21) "2"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 21)
-7: Call { head: [NodeId(0), NodeId(1)], args: [NodeId(2), NodeId(6)] } (5 to 22)
+7: Call { parts: [NodeId(0), NodeId(1), NodeId(2), NodeId(6)] } (5 to 22)
 8: Block(BlockId(0)) (0 to 23)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(8) (empty)
 ==== TYPES ====
 0: unknown
-1: unknown
-2: unknown
-3: unknown
-4: unknown
-5: unknown
-6: unknown
-7: unknown
+1: string
+2: string
+3: int
+4: forbidden
+5: int
+6: int
+7: stream<binary>
 8: ()
-==== TYPE ERRORS ====
-Error (NodeId 7): unsupported ast node 'Call { head: [NodeId(0), NodeId(1)], args: [NodeId(2), NodeId(6)] }' in typechecker

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -1,0 +1,29 @@
+---
+source: src/test.rs
+expression: evaluate_example(path)
+input_file: tests/calls.nu
+---
+==== COMPILER ====
+0: Name (0 to 4) "spam"
+1: Name (5 to 8) "foo"
+2: String (9 to 14) ""bar""
+3: Int (16 to 17) "1"
+4: Plus (18 to 19)
+5: Int (20 to 21) "2"
+6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 21)
+7: Call { head: [NodeId(0), NodeId(1)], args: [NodeId(2), NodeId(6)] } (5 to 22)
+8: Block(BlockId(0)) (0 to 23)
+==== SCOPE ====
+0: Frame Scope, node_id: NodeId(8) (empty)
+==== TYPES ====
+0: unknown
+1: unknown
+2: unknown
+3: unknown
+4: unknown
+5: unknown
+6: unknown
+7: unknown
+8: ()
+==== TYPE ERRORS ====
+Error (NodeId 7): unsupported ast node 'Call { head: [NodeId(0), NodeId(1)], args: [NodeId(2), NodeId(6)] }' in typechecker

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -12,9 +12,40 @@ input_file: tests/calls.nu
 5: Int (20 to 21) "2"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 21)
 7: Call { parts: [NodeId(0), NodeId(1), NodeId(2), NodeId(6)] } (5 to 22)
-8: Block(BlockId(0)) (0 to 23)
+8: Name (28 to 36) "existing"
+9: Name (38 to 39) "a"
+10: Name (41 to 47) "string"
+11: Type { name: NodeId(10), params: None, optional: false } (41 to 47)
+12: Param { name: NodeId(9), ty: Some(NodeId(11)) } (38 to 47)
+13: Name (49 to 50) "b"
+14: Name (52 to 58) "string"
+15: Type { name: NodeId(14), params: None, optional: false } (52 to 58)
+16: Param { name: NodeId(13), ty: Some(NodeId(15)) } (49 to 58)
+17: Name (60 to 61) "c"
+18: Name (63 to 66) "int"
+19: Type { name: NodeId(18), params: None, optional: false } (63 to 66)
+20: Param { name: NodeId(17), ty: Some(NodeId(19)) } (60 to 66)
+21: Params([NodeId(12), NodeId(16), NodeId(20)]) (37 to 67)
+22: Variable (72 to 74) "$a"
+23: Variable (76 to 78) "$b"
+24: Variable (80 to 82) "$c"
+25: List([NodeId(22), NodeId(23), NodeId(24)]) (70 to 82)
+26: Block(BlockId(0)) (68 to 85)
+27: Def { name: NodeId(8), params: NodeId(21), return_ty: None, block: NodeId(26) } (24 to 85)
+28: Name (86 to 94) "existing"
+29: Name (95 to 98) "foo"
+30: String (100 to 104) ""ba""
+31: Plus (105 to 106)
+32: String (107 to 110) ""r""
+33: BinaryOp { lhs: NodeId(30), op: NodeId(31), rhs: NodeId(32) } (100 to 110)
+34: Int (112 to 113) "3"
+35: Call { parts: [NodeId(28), NodeId(29), NodeId(33), NodeId(34)] } (95 to 113)
+36: Block(BlockId(1)) (0 to 114)
 ==== SCOPE ====
-0: Frame Scope, node_id: NodeId(8) (empty)
+0: Frame Scope, node_id: NodeId(36)
+      decls: [ existing: NodeId(8) ]
+1: Frame Scope, node_id: NodeId(26)
+  variables: [ a: NodeId(9), b: NodeId(13), c: NodeId(17) ]
 ==== TYPES ====
 0: unknown
 1: string
@@ -24,4 +55,32 @@ input_file: tests/calls.nu
 5: int
 6: int
 7: stream<binary>
-8: ()
+8: unknown
+9: unknown
+10: unknown
+11: string
+12: unknown
+13: unknown
+14: unknown
+15: string
+16: unknown
+17: unknown
+18: unknown
+19: int
+20: unknown
+21: unknown
+22: unknown
+23: unknown
+24: unknown
+25: list<unknown>
+26: ()
+27: ()
+28: unknown
+29: string
+30: string
+31: forbidden
+32: string
+33: string
+34: int
+35: any
+36: ()

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -4,9 +4,9 @@ expression: evaluate_example(path)
 input_file: tests/invalid_record.nu
 ---
 ==== COMPILER ====
-0: Name (2 to 3) "a"
+0: String (2 to 3) "a"
 1: Int (5 to 6) "1"
-2: Name (9 to 10) "b"
+2: String (9 to 10) "b"
 3: Garbage (11 to 12)
 4: Garbage (13 to 13)
 5: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(4))] } (0 to 0)

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -7,7 +7,7 @@ input_file: tests/literals.nu
 0: True (1 to 5)
 1: Null (6 to 10)
 2: Int (11 to 12) "1"
-3: Name (13 to 16) "abc"
+3: String (13 to 16) "abc"
 4: String (17 to 22) ""foo""
 5: List([NodeId(0), NodeId(1), NodeId(2), NodeId(3), NodeId(4)]) (0 to 22)
 6: Block(BlockId(0)) (0 to 24)
@@ -17,9 +17,7 @@ input_file: tests/literals.nu
 0: bool
 1: nothing
 2: int
-3: unknown
+3: string
 4: string
 5: list<any>
 6: ()
-==== TYPE ERRORS ====
-Error (NodeId 3): unsupported ast node 'Name' in typechecker

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -4,9 +4,9 @@ expression: evaluate_example(path)
 input_file: tests/record.nu
 ---
 ==== COMPILER ====
-0: Name (1 to 2) "a"
+0: String (1 to 2) "a"
 1: Int (4 to 5) "1"
-2: Name (7 to 8) "b"
+2: String (7 to 8) "b"
 3: Int (10 to 11) "2"
 4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 12)
 5: Block(BlockId(0)) (0 to 13)

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -4,9 +4,9 @@ expression: evaluate_example(path)
 input_file: tests/record3.nu
 ---
 ==== COMPILER ====
-0: Name (2 to 3) "a"
+0: String (2 to 3) "a"
 1: Int (5 to 6) "1"
-2: Name (9 to 10) "b"
+2: String (9 to 10) "b"
 3: Int (12 to 13) "2"
 4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 16)
 5: Block(BlockId(0)) (0 to 17)

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -13,8 +13,8 @@ input_file: tests/reparse.nu
 6: Closure { params: Some(NodeId(3)), block: NodeId(5) } (8 to 17)
 7: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(6), is_mutable: false } (0 to 17)
 8: Variable (22 to 23) "y"
-9: Name (28 to 29) "a"
-10: Name (31 to 32) "b"
+9: String (28 to 29) "a"
+10: String (31 to 32) "b"
 11: Record { pairs: [(NodeId(9), NodeId(10))] } (26 to 34)
 12: Let { variable_name: NodeId(8), ty: None, initializer: NodeId(11), is_mutable: false } (18 to 34)
 13: Block(BlockId(1)) (0 to 34)

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -4,8 +4,8 @@ expression: evaluate_example(path)
 input_file: tests/table2.nu
 ---
 ==== COMPILER ====
-0: Name (7 to 8) "a"
-1: Name (10 to 11) "b"
+0: String (7 to 8) "a"
+1: String (10 to 11) "b"
 2: List([NodeId(0), NodeId(1)]) (6 to 11)
 3: Int (20 to 21) "1"
 4: Int (23 to 24) "2"

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -401,7 +401,7 @@ impl<'a> Typechecker<'a> {
 
     fn typecheck_def(
         &mut self,
-        _name: NodeId,
+        name: NodeId,
         params: NodeId,
         _return_ty: Option<NodeId>,
         block: NodeId,
@@ -415,7 +415,7 @@ impl<'a> Typechecker<'a> {
         let decl_id = self
             .compiler
             .decl_resolution
-            .get(&node_id)
+            .get(&name)
             .expect("missing declared decl");
 
         self.decl_types[decl_id.0] = vec![InOutType {

--- a/tests/binary_ops_exact.nu
+++ b/tests/binary_ops_exact.nu
@@ -2,4 +2,4 @@
 [true] ++ false
 1 + 1
 1.0 + 1.0
-true and false # TODO: "and" marked as Name
+true and false

--- a/tests/calls.nu
+++ b/tests/calls.nu
@@ -1,1 +1,4 @@
 spam foo "bar" (1 + 2)
+
+def existing [a: string, b: string, c: int] { [ $a, $b, $c] }
+existing foo ("ba" + "r") 3

--- a/tests/calls.nu
+++ b/tests/calls.nu
@@ -1,0 +1,1 @@
+spam foo "bar" (1 + 2)


### PR DESCRIPTION
Starts parsing, resolving and typechecking of calls.

Introduces some adjacent topics as well:
* The notion of barewords in command vs. value position
* Barewords can follow different naming rules depending on their position (see `naming.rs`).
* `binary` and `stream<...>` types. Not used anywhere yet, except `stream<binary>` is the output of external calls
* `and` and `or` are parsed as operators now (required the barewords refactor)