### PR TITLE
Add an assert than offset increases after next().

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2191,7 +2191,10 @@ impl Parser {
                 }
             }
         }
-
+        assert_ne!(
+            self.span_offset, span_position,
+            "lex_bareword did not consume any bytes"
+        );
         self.span_offset = span_position;
 
         Some(Token {
@@ -2581,6 +2584,8 @@ impl Parser {
         self.next_bareword(NameStrictness::Strict)
     }
 
+    // Returns next token, or None if end of source has been reached.
+    // If token is returned, the span_offset is increased.
     pub fn next_bareword(&mut self, name_strictness: NameStrictness) -> Option<Token> {
         let _span = span!();
 


### PR DESCRIPTION
When the source code is incorrect, in some cases lex_bareword will return "empty" token (where start == end). This leads to infinite loop, where the same empty token is returned on every call to next().

This is just temporary solution, to prefer crash with assert instead of infinite loop.