### PR TITLE
Suport paths in lex_bareword

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2177,7 +2177,10 @@ impl Parser {
                 while span_position < self.compiler.source.len()
                     && !self.compiler.source[span_position].is_ascii_whitespace()
                     && (!self.compiler.source[span_position].is_ascii_punctuation()
-                        || self.compiler.source[span_position] == b'_')
+                        || self.compiler.source[span_position] == b'_'
+                        || self.compiler.source[span_position] == b'/'
+                        || self.compiler.source[span_position] == b'\\'
+                        || self.compiler.source[span_position] == b'.')
                 {
                     span_position += 1;
                 }

--- a/src/snapshots/new_nu_parser__test__node_output@path.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@path.nu.snap
@@ -1,0 +1,30 @@
+---
+source: src/test.rs
+expression: evaluate_example(path)
+input_file: tests/path.nu
+snapshot_kind: text
+---
+==== COMPILER ====
+0: Name (0 to 2) "ls"
+1: Name (3 to 9) "foo.nu"
+2: Call { parts: [NodeId(0), NodeId(1)] } (3 to 9)
+3: Name (10 to 12) "ls"
+4: Name (13 to 21) "foo/bar/"
+5: Call { parts: [NodeId(3), NodeId(4)] } (13 to 21)
+6: Name (22 to 24) "ls"
+7: Name (25 to 39) "foo/bar/baz.nu"
+8: Call { parts: [NodeId(6), NodeId(7)] } (25 to 39)
+9: Block(BlockId(0)) (0 to 40)
+==== SCOPE ====
+0: Frame Scope, node_id: NodeId(9) (empty)
+==== TYPES ====
+0: unknown
+1: string
+2: stream<binary>
+3: unknown
+4: string
+5: stream<binary>
+6: unknown
+7: string
+8: stream<binary>
+9: stream<binary>

--- a/tests/path.nu
+++ b/tests/path.nu
@@ -1,0 +1,3 @@
+ls foo.nu
+ls foo/bar/
+ls foo/bar/baz.nu


### PR DESCRIPTION
It is allowed to pass a path as bareword in nu, e.g. in `ls` or `use` commands.