### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# The toolchain should follow the version in nushell/nushell repository.
+[toolchain]
+# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+profile = "default"
+channel = "1.81.0"


### PR DESCRIPTION
This is matching the rust-toolchain file from the main nushell/nushell repository, and ensures we are developing on the same version of rust.