### PR TITLE
Add lexing of rawstring

### DIFF
--- a/src/snapshots/new_nu_parser__test__lexer@raw_string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__lexer@raw_string.nu.snap
@@ -1,0 +1,14 @@
+---
+source: src/test.rs
+expression: evaluate_lexer(path)
+input_file: tests/lex/raw_string.nu
+snapshot_kind: text
+---
+==== TOKENS ====
+Token3    0: RawString                 span:    0 ..    9 'r#'aabb'#'
+Token3    1: Newline                   span:    9 ..   10 '\n'
+Token3    2: RawString                 span:   10 ..   25 'r##'aa\n'#\nbb'##'
+Token3    3: Newline                   span:   25 ..   26 '\n'
+Token3    4: RawString                 span:   26 ..   58 'r####'aa\nbb\ncc'##dd\n###\nddd'####'
+Token3    5: Newline                   span:   58 ..   59 '\n'
+Token3    6: Eof                       span:   59 ..   59 ''

--- a/tests/lex/raw_string.nu
+++ b/tests/lex/raw_string.nu
@@ -1,0 +1,9 @@
+r#'aabb'#
+r##'aa
+'#
+bb'##
+r####'aa
+bb
+cc'##dd
+###
+ddd'####


### PR DESCRIPTION
As title.  This pr is going to make nushell support lexing of rawstring, which have the syntax:
- `r#'<content>'#`
- `r##'<content>'##`
- `r###'<content>'###`
- etc...

To implement this, just need to move forward to find the ending mark of the raw string.