### PR TITLE
`return_ty` -> `in_out_types`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -130,7 +130,7 @@ pub enum AstNode {
     Def {
         name: NodeId,
         params: NodeId,
-        return_ty: Option<NodeId>,
+        in_out_types: Option<NodeId>,
         block: NodeId,
     },
     Params(Vec<NodeId>),
@@ -1051,7 +1051,7 @@ impl Parser {
         };
 
         let params = self.signature_params(ParamsContext::Squares);
-        let return_ty = if self.is_colon() {
+        let in_out_types = if self.is_colon() {
             Some(self.in_out_types())
         } else {
             None
@@ -1064,7 +1064,7 @@ impl Parser {
             AstNode::Def {
                 name,
                 params,
-                return_ty,
+                in_out_types,
                 block,
             },
             span_start,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -221,7 +221,7 @@ impl<'a> Resolver<'a> {
             AstNode::Def {
                 name,
                 params,
-                return_ty: _,
+                in_out_types: _,
                 block,
             } => {
                 // define the command before the block to enable recursive calls

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/calls.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Name (0 to 4) "spam"
@@ -32,7 +31,7 @@ snapshot_kind: text
 24: Variable (80 to 82) "$c"
 25: List([NodeId(22), NodeId(23), NodeId(24)]) (70 to 82)
 26: Block(BlockId(0)) (68 to 85)
-27: Def { name: NodeId(8), params: NodeId(21), return_ty: None, block: NodeId(26) } (24 to 85)
+27: Def { name: NodeId(8), params: NodeId(21), in_out_types: None, block: NodeId(26) } (24 to 85)
 28: Name (86 to 94) "existing"
 29: Name (95 to 98) "foo"
 30: String (100 to 104) ""ba""

--- a/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/def.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Name (4 to 7) "foo"
@@ -28,7 +27,7 @@ snapshot_kind: text
 20: Variable (51 to 53) "$z"
 21: List([NodeId(18), NodeId(19), NodeId(20)]) (42 to 54)
 22: Block(BlockId(0)) (40 to 57)
-23: Def { name: NodeId(0), params: NodeId(17), return_ty: None, block: NodeId(22) } (0 to 57)
+23: Def { name: NodeId(0), params: NodeId(17), in_out_types: None, block: NodeId(22) } (0 to 57)
 24: Block(BlockId(1)) (0 to 57)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(24)
@@ -65,4 +64,4 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 23): node Def { name: NodeId(0), params: NodeId(17), return_ty: None, block: NodeId(22) } not suported yet
+Error (NodeId 23): node Def { name: NodeId(0), params: NodeId(17), in_out_types: None, block: NodeId(22) } not suported yet

--- a/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/def_return_type.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Name (4 to 7) "foo"
@@ -18,7 +17,7 @@ snapshot_kind: text
 10: InOutTypes([NodeId(9)]) (14 to 35)
 11: List([]) (37 to 38)
 12: Block(BlockId(0)) (35 to 41)
-13: Def { name: NodeId(0), params: NodeId(1), return_ty: Some(NodeId(10)), block: NodeId(12) } (0 to 41)
+13: Def { name: NodeId(0), params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12) } (0 to 41)
 14: Name (46 to 49) "bar"
 15: Params([]) (50 to 53)
 16: Name (58 to 64) "string"
@@ -40,7 +39,7 @@ snapshot_kind: text
 32: InOutTypes([NodeId(23), NodeId(31)]) (56 to 101)
 33: List([]) (103 to 104)
 34: Block(BlockId(1)) (101 to 107)
-35: Def { name: NodeId(14), params: NodeId(15), return_ty: Some(NodeId(32)), block: NodeId(34) } (42 to 107)
+35: Def { name: NodeId(14), params: NodeId(15), in_out_types: Some(NodeId(32)), block: NodeId(34) } (42 to 107)
 36: Block(BlockId(2)) (0 to 108)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(36)
@@ -89,4 +88,4 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 13): node Def { name: NodeId(0), params: NodeId(1), return_ty: Some(NodeId(10)), block: NodeId(12) } not suported yet
+Error (NodeId 13): node Def { name: NodeId(0), params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12) } not suported yet

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/invalid_types.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Name (4 to 7) "foo"
@@ -18,7 +17,7 @@ snapshot_kind: text
 10: Params([NodeId(9)]) (8 to 30)
 11: Variable (33 to 35) "$x"
 12: Block(BlockId(0)) (31 to 37)
-13: Def { name: NodeId(0), params: NodeId(10), return_ty: None, block: NodeId(12) } (0 to 37)
+13: Def { name: NodeId(0), params: NodeId(10), in_out_types: None, block: NodeId(12) } (0 to 37)
 14: Name (42 to 45) "bar"
 15: Name (47 to 48) "y"
 16: Name (50 to 54) "list"
@@ -28,7 +27,7 @@ snapshot_kind: text
 20: Params([NodeId(19)]) (46 to 57)
 21: Variable (60 to 62) "$y"
 22: Block(BlockId(1)) (58 to 64)
-23: Def { name: NodeId(14), params: NodeId(20), return_ty: None, block: NodeId(22) } (38 to 64)
+23: Def { name: NodeId(14), params: NodeId(20), in_out_types: None, block: NodeId(22) } (38 to 64)
 24: Block(BlockId(2)) (0 to 65)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(24)
@@ -70,4 +69,4 @@ Error (NodeId 17): list must have one type parameter
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 13): node Def { name: NodeId(0), params: NodeId(10), return_ty: None, block: NodeId(12) } not suported yet
+Error (NodeId 13): node Def { name: NodeId(0), params: NodeId(10), in_out_types: None, block: NodeId(12) } not suported yet

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -345,9 +345,9 @@ impl<'a> Typechecker<'a> {
             AstNode::Def {
                 name,
                 params,
-                return_ty,
+                in_out_types,
                 block,
-            } => self.typecheck_def(name, params, return_ty, block, node_id),
+            } => self.typecheck_def(name, params, in_out_types, block, node_id),
             AstNode::Alias { new_name, old_name } => {
                 self.typecheck_alias(new_name, old_name, node_id)
             }
@@ -626,11 +626,11 @@ impl<'a> Typechecker<'a> {
         &mut self,
         name: NodeId,
         params: NodeId,
-        return_ty: Option<NodeId>,
+        in_out_types: Option<NodeId>,
         block: NodeId,
         node_id: NodeId,
     ) {
-        let return_ty = return_ty
+        let in_out_types = in_out_types
             .map(|ty| {
                 let AstNode::InOutTypes(types) = self.compiler.get_node(ty) else {
                     panic!("internal error: return type is not a return type");
@@ -677,14 +677,14 @@ impl<'a> Typechecker<'a> {
             .get(&name)
             .expect("missing declared decl");
 
-        if return_ty.is_empty() {
+        if in_out_types.is_empty() {
             self.decl_types[decl_id.0] = vec![InOutType {
                 in_type: ANY_TYPE,
                 out_type: self.type_id_of(block),
             }];
         } else {
             // TODO check that block output type matches expected type
-            self.decl_types[decl_id.0] = return_ty;
+            self.decl_types[decl_id.0] = in_out_types;
         }
     }
 


### PR DESCRIPTION
Since https://github.com/nushell/new-nu-parser/pull/46, defs have a list of input-output type pairs rather than a single return type, so as per @kubouch's suggestion on that PR, I've renamed `return_ty` to `in_out_types` everywhere.