### PR TITLE
Ci: use ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Pinning to Ubuntu 22.04 because building on newer Ubuntu versions causes linux-gnu
+        # Pinning to Ubuntu 24.04 because building on newer Ubuntu versions causes linux-gnu
         # builds to link against a too-new-for-many-Linux-installs glibc version. Consider
-        # revisiting this when 22.04 is closer to EOL (June 2027)
-        platform: [macos-latest, ubuntu-22.04]
+        # revisiting this when 24.04 is closer to EOL
+        platform: [macos-latest, ubuntu-24.04]
         feature: [default]
         include:
           - feature: default
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [macos-latest, ubuntu-22.04]
+        platform: [macos-latest, ubuntu-24.04]
         feature: [default]
         include:
           - feature: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [macos-latest, ubuntu-20.04]
+        platform: [macos-latest, ubuntu-22.04]
         feature: [default]
         include:
           - feature: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Pinning to Ubuntu 20.04 because building on newer Ubuntu versions causes linux-gnu
+        # Pinning to Ubuntu 22.04 because building on newer Ubuntu versions causes linux-gnu
         # builds to link against a too-new-for-many-Linux-installs glibc version. Consider
-        # revisiting this when 20.04 is closer to EOL (April 2025)
-        platform: [macos-latest, ubuntu-20.04]
+        # revisiting this when 22.04 is closer to EOL (June 2027)
+        platform: [macos-latest, ubuntu-22.04]
         feature: [default]
         include:
           - feature: default


### PR DESCRIPTION
Just notice ubuntu-20.04 is removed on 2025-04-15, so it's no longer usable.
This pr is going to update to ubuntu-24.04