### PR TITLE
Implement `Copy` trait on `AstNode`

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, NodeId, Pipeline};
+use crate::parser::{AstNode, Block, NodeId, Params, Pipeline};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -12,6 +12,7 @@ pub struct RollbackPoint {
     idx_nodes: usize,
     idx_errors: usize,
     idx_blocks: usize,
+    idx_params: usize,
     token_pos: usize,
 }
 
@@ -47,6 +48,7 @@ pub struct Compiler {
     pub node_types: Vec<TypeId>,
     // node_lifetimes: Vec<AllocationLifetime>,
     pub blocks: Vec<Block>,       // Blocks, indexed by BlockId
+    pub params: Vec<Params>,      // Params, indexed by ParamsId
     pub pipelines: Vec<Pipeline>, // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
@@ -95,6 +97,7 @@ impl Compiler {
             ast_nodes: vec![],
             node_types: vec![],
             blocks: vec![],
+            params: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -211,12 +214,14 @@ impl Compiler {
             idx_nodes: self.ast_nodes.len(),
             idx_errors: self.errors.len(),
             idx_blocks: self.blocks.len(),
+            idx_params: self.params.len(),
             token_pos,
         }
     }
 
     pub fn apply_compiler_rollback(&mut self, rbp: RollbackPoint) -> usize {
         self.blocks.truncate(rbp.idx_blocks);
+        self.params.truncate(rbp.idx_params);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -269,5 +274,15 @@ impl Compiler {
             );
         };
         &self.blocks[block_id.0]
+    }
+
+    pub fn get_params(&self, node_id: NodeId) -> &Params {
+        let AstNode::Params(params_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected params, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.params[params_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,7 @@
 use crate::errors::SourceError;
 use crate::parser::{
-    AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline, Record, Table,
+    AstNode, Block, Call, InOutTypes, List, Match, NodeId, Params, Pipeline, Record, Table,
+    TypeArgs,
 };
 use crate::protocol::Command;
 use crate::resolver::{
@@ -20,6 +21,8 @@ pub struct RollbackPoint {
     idx_lists: usize,
     idx_tables: usize,
     idx_records: usize,
+    idx_matches: usize,
+    idx_type_args: usize,
     token_pos: usize,
 }
 
@@ -54,14 +57,16 @@ pub struct Compiler {
     pub ast_nodes: Vec<AstNode>,
     pub node_types: Vec<TypeId>,
     // node_lifetimes: Vec<AllocationLifetime>,
-    pub blocks: Vec<Block>,             // Blocks, indexed by BlockId
-    pub params: Vec<Params>,            // Params, indexed by ParamsId
-    pub in_out_types: Vec<InOutTypes>,  // InOutTypes, indexed by InOutTypesId
-    pub calls: Vec<Call>,               // Calls, indexed by CallId
-    pub lists: Vec<List>,               // Lists, indexed by ListId
-    pub tables: Vec<Table>,             // Tables, indexed by TableId
-    pub records: Vec<Record>,           // Records, indexed by RecordId
-    pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
+    pub blocks: Vec<Block>,            // Blocks, indexed by BlockId
+    pub params: Vec<Params>,           // Params, indexed by ParamsId
+    pub in_out_types: Vec<InOutTypes>, // InOutTypes, indexed by InOutTypesId
+    pub calls: Vec<Call>,              // Calls, indexed by CallId
+    pub lists: Vec<List>,              // Lists, indexed by ListId
+    pub tables: Vec<Table>,            // Tables, indexed by TableId
+    pub records: Vec<Record>,          // Records, indexed by RecordId
+    pub matches: Vec<Match>,           // Matches, indexed by MatchId
+    pub type_args: Vec<TypeArgs>,      // TypeArgs, indexed by TypeArgsId
+    pub pipelines: Vec<Pipeline>,      // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
 
@@ -115,6 +120,8 @@ impl Compiler {
             lists: vec![],
             tables: vec![],
             records: vec![],
+            matches: vec![],
+            type_args: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -237,6 +244,8 @@ impl Compiler {
             idx_lists: self.lists.len(),
             idx_tables: self.tables.len(),
             idx_records: self.records.len(),
+            idx_matches: self.matches.len(),
+            idx_type_args: self.type_args.len(),
             token_pos,
         }
     }
@@ -249,6 +258,8 @@ impl Compiler {
         self.lists.truncate(rbp.idx_lists);
         self.tables.truncate(rbp.idx_tables);
         self.records.truncate(rbp.idx_records);
+        self.matches.truncate(rbp.idx_matches);
+        self.type_args.truncate(rbp.idx_type_args);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -361,5 +372,25 @@ impl Compiler {
             );
         };
         &self.records[record_id.0]
+    }
+
+    pub fn get_match(&self, node_id: NodeId) -> &Match {
+        let AstNode::Match(match_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected match, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.matches[match_id.0]
+    }
+
+    pub fn get_type_args(&self, node_id: NodeId) -> &TypeArgs {
+        let AstNode::TypeArgs(type_args_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected type args, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.type_args[type_args_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, InOutTypes, NodeId, Params, Pipeline};
+use crate::parser::{AstNode, Block, Call, InOutTypes, NodeId, Params, Pipeline};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -14,6 +14,7 @@ pub struct RollbackPoint {
     idx_blocks: usize,
     idx_params: usize,
     idx_in_out_types: usize,
+    idx_calls: usize,
     token_pos: usize,
 }
 
@@ -51,6 +52,7 @@ pub struct Compiler {
     pub blocks: Vec<Block>,             // Blocks, indexed by BlockId
     pub params: Vec<Params>,            // Params, indexed by ParamsId
     pub in_out_types: Vec<InOutTypes>,  // InOutTypes, indexed by InOutTypesId
+    pub calls: Vec<Call>,               // Calls, indexed by CallId
     pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
@@ -101,6 +103,7 @@ impl Compiler {
             blocks: vec![],
             params: vec![],
             in_out_types: vec![],
+            calls: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -219,6 +222,7 @@ impl Compiler {
             idx_blocks: self.blocks.len(),
             idx_params: self.params.len(),
             idx_in_out_types: self.in_out_types.len(),
+            idx_calls: self.calls.len(),
             token_pos,
         }
     }
@@ -227,6 +231,7 @@ impl Compiler {
         self.blocks.truncate(rbp.idx_blocks);
         self.params.truncate(rbp.idx_params);
         self.in_out_types.truncate(rbp.idx_in_out_types);
+        self.calls.truncate(rbp.idx_calls);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -299,5 +304,15 @@ impl Compiler {
             );
         };
         &self.in_out_types[in_out_types_id.0]
+    }
+
+    pub fn get_call(&self, node_id: NodeId) -> &Call {
+        let AstNode::Call(call_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected call, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.calls[call_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline};
+use crate::parser::{AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline, Table};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -16,6 +16,7 @@ pub struct RollbackPoint {
     idx_in_out_types: usize,
     idx_calls: usize,
     idx_lists: usize,
+    idx_tables: usize,
     token_pos: usize,
 }
 
@@ -55,6 +56,7 @@ pub struct Compiler {
     pub in_out_types: Vec<InOutTypes>,  // InOutTypes, indexed by InOutTypesId
     pub calls: Vec<Call>,               // Calls, indexed by CallId
     pub lists: Vec<List>,               // Lists, indexed by ListId
+    pub tables: Vec<Table>,             // Tables, indexed by TableId
     pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
@@ -107,6 +109,7 @@ impl Compiler {
             in_out_types: vec![],
             calls: vec![],
             lists: vec![],
+            tables: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -227,6 +230,7 @@ impl Compiler {
             idx_in_out_types: self.in_out_types.len(),
             idx_calls: self.calls.len(),
             idx_lists: self.lists.len(),
+            idx_tables: self.tables.len(),
             token_pos,
         }
     }
@@ -237,6 +241,7 @@ impl Compiler {
         self.in_out_types.truncate(rbp.idx_in_out_types);
         self.calls.truncate(rbp.idx_calls);
         self.lists.truncate(rbp.idx_lists);
+        self.tables.truncate(rbp.idx_tables);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -329,5 +334,15 @@ impl Compiler {
             );
         };
         &self.lists[list_id.0]
+    }
+
+    pub fn get_table(&self, node_id: NodeId) -> &Table {
+        let AstNode::Table(table_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected table, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.tables[table_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,7 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline, Table};
+use crate::parser::{
+    AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline, Record, Table,
+};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -17,6 +19,7 @@ pub struct RollbackPoint {
     idx_calls: usize,
     idx_lists: usize,
     idx_tables: usize,
+    idx_records: usize,
     token_pos: usize,
 }
 
@@ -57,6 +60,7 @@ pub struct Compiler {
     pub calls: Vec<Call>,               // Calls, indexed by CallId
     pub lists: Vec<List>,               // Lists, indexed by ListId
     pub tables: Vec<Table>,             // Tables, indexed by TableId
+    pub records: Vec<Record>,           // Records, indexed by RecordId
     pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
@@ -110,6 +114,7 @@ impl Compiler {
             calls: vec![],
             lists: vec![],
             tables: vec![],
+            records: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -231,6 +236,7 @@ impl Compiler {
             idx_calls: self.calls.len(),
             idx_lists: self.lists.len(),
             idx_tables: self.tables.len(),
+            idx_records: self.records.len(),
             token_pos,
         }
     }
@@ -242,6 +248,7 @@ impl Compiler {
         self.calls.truncate(rbp.idx_calls);
         self.lists.truncate(rbp.idx_lists);
         self.tables.truncate(rbp.idx_tables);
+        self.records.truncate(rbp.idx_records);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -344,5 +351,15 @@ impl Compiler {
             );
         };
         &self.tables[table_id.0]
+    }
+
+    pub fn get_record(&self, node_id: NodeId) -> &Record {
+        let AstNode::Record(record_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected record, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.records[record_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, Call, InOutTypes, NodeId, Params, Pipeline};
+use crate::parser::{AstNode, Block, Call, InOutTypes, List, NodeId, Params, Pipeline};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -15,6 +15,7 @@ pub struct RollbackPoint {
     idx_params: usize,
     idx_in_out_types: usize,
     idx_calls: usize,
+    idx_lists: usize,
     token_pos: usize,
 }
 
@@ -53,6 +54,7 @@ pub struct Compiler {
     pub params: Vec<Params>,            // Params, indexed by ParamsId
     pub in_out_types: Vec<InOutTypes>,  // InOutTypes, indexed by InOutTypesId
     pub calls: Vec<Call>,               // Calls, indexed by CallId
+    pub lists: Vec<List>,               // Lists, indexed by ListId
     pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
@@ -104,6 +106,7 @@ impl Compiler {
             params: vec![],
             in_out_types: vec![],
             calls: vec![],
+            lists: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -223,6 +226,7 @@ impl Compiler {
             idx_params: self.params.len(),
             idx_in_out_types: self.in_out_types.len(),
             idx_calls: self.calls.len(),
+            idx_lists: self.lists.len(),
             token_pos,
         }
     }
@@ -232,6 +236,7 @@ impl Compiler {
         self.params.truncate(rbp.idx_params);
         self.in_out_types.truncate(rbp.idx_in_out_types);
         self.calls.truncate(rbp.idx_calls);
+        self.lists.truncate(rbp.idx_lists);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -314,5 +319,15 @@ impl Compiler {
             );
         };
         &self.calls[call_id.0]
+    }
+
+    pub fn get_list(&self, node_id: NodeId) -> &List {
+        let AstNode::List(list_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected list, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.lists[list_id.0]
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::errors::SourceError;
-use crate::parser::{AstNode, Block, NodeId, Params, Pipeline};
+use crate::parser::{AstNode, Block, InOutTypes, NodeId, Params, Pipeline};
 use crate::protocol::Command;
 use crate::resolver::{
     DeclId, Frame, NameBindings, ScopeId, TypeDecl, TypeDeclId, VarId, Variable,
@@ -13,6 +13,7 @@ pub struct RollbackPoint {
     idx_errors: usize,
     idx_blocks: usize,
     idx_params: usize,
+    idx_in_out_types: usize,
     token_pos: usize,
 }
 
@@ -47,9 +48,10 @@ pub struct Compiler {
     pub ast_nodes: Vec<AstNode>,
     pub node_types: Vec<TypeId>,
     // node_lifetimes: Vec<AllocationLifetime>,
-    pub blocks: Vec<Block>,       // Blocks, indexed by BlockId
-    pub params: Vec<Params>,      // Params, indexed by ParamsId
-    pub pipelines: Vec<Pipeline>, // Pipelines, indexed by PipelineId
+    pub blocks: Vec<Block>,             // Blocks, indexed by BlockId
+    pub params: Vec<Params>,            // Params, indexed by ParamsId
+    pub in_out_types: Vec<InOutTypes>,  // InOutTypes, indexed by InOutTypesId
+    pub pipelines: Vec<Pipeline>,       // Pipelines, indexed by PipelineId
     pub source: Vec<u8>,
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
 
@@ -98,6 +100,7 @@ impl Compiler {
             node_types: vec![],
             blocks: vec![],
             params: vec![],
+            in_out_types: vec![],
             pipelines: vec![],
             source: vec![],
             file_offsets: vec![],
@@ -215,6 +218,7 @@ impl Compiler {
             idx_errors: self.errors.len(),
             idx_blocks: self.blocks.len(),
             idx_params: self.params.len(),
+            idx_in_out_types: self.in_out_types.len(),
             token_pos,
         }
     }
@@ -222,6 +226,7 @@ impl Compiler {
     pub fn apply_compiler_rollback(&mut self, rbp: RollbackPoint) -> usize {
         self.blocks.truncate(rbp.idx_blocks);
         self.params.truncate(rbp.idx_params);
+        self.in_out_types.truncate(rbp.idx_in_out_types);
         self.ast_nodes.truncate(rbp.idx_nodes);
         self.errors.truncate(rbp.idx_errors);
         self.spans.truncate(rbp.idx_span_start);
@@ -284,5 +289,15 @@ impl Compiler {
             );
         };
         &self.params[params_id.0]
+    }
+
+    pub fn get_in_out_types(&self, node_id: NodeId) -> &InOutTypes {
+        let AstNode::InOutTypes(in_out_types_id) = self.ast_nodes[node_id.0] else {
+            unreachable!(
+                "internal error: expected in_out_types, got '{:?}'",
+                self.ast_nodes[node_id.0]
+            );
+        };
+        &self.in_out_types[in_out_types_id.0]
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,6 +31,9 @@ pub struct ListId(pub usize);
 pub struct TableId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RecordId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -97,6 +100,17 @@ pub struct Table {
 impl Table {
     pub fn new(header: NodeId, rows: Vec<NodeId>) -> Self {
         Self { header, rows }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Record {
+    pub pairs: Vec<(NodeId, NodeId)>,
+}
+
+impl Record {
+    pub fn new(pairs: Vec<(NodeId, NodeId)>) -> Self {
+        Self { pairs }
     }
 }
 
@@ -302,9 +316,7 @@ pub enum AstNode {
     },
     List(ListId),
     Table(TableId),
-    Record {
-        pairs: Vec<(NodeId, NodeId)>,
-    },
+    Record(RecordId),
     MemberAccess {
         target: NodeId,
         field: NodeId,
@@ -843,7 +855,12 @@ impl Parser {
                 span_end,
             )
         } else {
-            self.create_node(AstNode::Record { pairs: items }, span_start, span_end)
+            self.compiler.records.push(Record::new(items));
+            self.create_node(
+                AstNode::Record(RecordId(self.compiler.records.len() - 1)),
+                span_start,
+                span_end,
+            )
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,9 @@ pub struct ParamsId(pub usize);
 pub struct InOutTypesId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CallId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -54,6 +57,17 @@ pub struct InOutTypes {
 impl InOutTypes {
     pub fn new(nodes: Vec<NodeId>) -> Self {
         Self { nodes }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Call {
+    pub parts: Vec<NodeId>,
+}
+
+impl Call {
+    pub fn new(parts: Vec<NodeId>) -> Self {
+        Self { parts }
     }
 }
 
@@ -243,9 +257,7 @@ pub enum AstNode {
     FlagShortGroup,
 
     // Expressions
-    Call {
-        parts: Vec<NodeId>,
-    },
+    Call(CallId),
     NamedValue {
         name: NodeId,
         value: NodeId,
@@ -675,7 +687,12 @@ impl Parser {
 
         let span_end = self.position();
 
-        self.create_node(AstNode::Call { parts }, span_start, span_end)
+        self.compiler.calls.push(Call::new(parts));
+        self.create_node(
+            AstNode::Call(CallId(self.compiler.calls.len() - 1)),
+            span_start,
+            span_end,
+        )
     }
 
     pub fn list_or_table(&mut self) -> NodeId {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,9 @@ pub struct BlockId(pub usize);
 pub struct ParamsId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InOutTypesId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -38,6 +41,17 @@ pub struct Params {
 }
 
 impl Params {
+    pub fn new(nodes: Vec<NodeId>) -> Self {
+        Self { nodes }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InOutTypes {
+    pub nodes: Vec<NodeId>,
+}
+
+impl InOutTypes {
     pub fn new(nodes: Vec<NodeId>) -> Self {
         Self { nodes }
     }
@@ -209,7 +223,7 @@ pub enum AstNode {
         name: NodeId,
         ty: Option<NodeId>,
     },
-    InOutTypes(Vec<NodeId>),
+    InOutTypes(InOutTypesId),
     /// Input/output type pair for a command
     InOutType(NodeId, NodeId),
     Closure {
@@ -1247,11 +1261,21 @@ impl Parser {
             self.rsquare();
             let span_end = self.position();
 
-            self.create_node(AstNode::InOutTypes(output), span_start, span_end)
+            self.compiler.in_out_types.push(InOutTypes::new(output));
+            self.create_node(
+                AstNode::InOutTypes(InOutTypesId(self.compiler.in_out_types.len() - 1)),
+                span_start,
+                span_end,
+            )
         } else {
             let ty = self.in_out_type();
             let span = self.compiler.get_span(ty);
-            self.create_node(AstNode::InOutTypes(vec![ty]), span.start, span.end)
+            self.compiler.in_out_types.push(InOutTypes::new(vec![ty]));
+            self.create_node(
+                AstNode::InOutTypes(InOutTypesId(self.compiler.in_out_types.len() - 1)),
+                span.start,
+                span.end,
+            )
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,6 +16,9 @@ pub struct NodeId(pub usize);
 pub struct BlockId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ParamsId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -26,6 +29,17 @@ pub struct Block {
 impl Block {
     pub fn new(nodes: Vec<NodeId>) -> Block {
         Block { nodes }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Params {
+    pub nodes: Vec<NodeId>,
+}
+
+impl Params {
+    pub fn new(nodes: Vec<NodeId>) -> Self {
+        Self { nodes }
     }
 }
 
@@ -190,7 +204,7 @@ pub enum AstNode {
         name: NodeId,
         params: NodeId,
     },
-    Params(Vec<NodeId>),
+    Params(ParamsId),
     Param {
         name: NodeId,
         ty: Option<NodeId>,
@@ -1075,7 +1089,12 @@ impl Parser {
             output
         };
 
-        self.create_node(AstNode::Params(param_list), span_start, span_end)
+        self.compiler.params.push(Params::new(param_list));
+        self.create_node(
+            AstNode::Params(ParamsId(self.compiler.params.len() - 1)),
+            span_start,
+            span_end,
+        )
     }
 
     pub fn type_params(&mut self) -> NodeId {
@@ -1101,7 +1120,12 @@ impl Parser {
         let span_end = self.position() + 1;
         self.greater_than();
 
-        self.create_node(AstNode::Params(param_list), span_start, span_end)
+        self.compiler.params.push(Params::new(param_list));
+        self.create_node(
+            AstNode::Params(ParamsId(self.compiler.params.len() - 1)),
+            span_start,
+            span_end,
+        )
     }
 
     pub fn type_args(&mut self) -> NodeId {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,6 +28,9 @@ pub struct CallId(pub usize);
 pub struct ListId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TableId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -82,6 +85,18 @@ pub struct List {
 impl List {
     pub fn new(items: Vec<NodeId>) -> Self {
         Self { items }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Table {
+    pub header: NodeId,
+    pub rows: Vec<NodeId>,
+}
+
+impl Table {
+    pub fn new(header: NodeId, rows: Vec<NodeId>) -> Self {
+        Self { header, rows }
     }
 }
 
@@ -286,10 +301,7 @@ pub enum AstNode {
         rhs: NodeId,
     },
     List(ListId),
-    Table {
-        header: NodeId,
-        rows: Vec<NodeId>,
-    },
+    Table(TableId),
     Record {
         pairs: Vec<(NodeId, NodeId)>,
     },
@@ -747,11 +759,9 @@ impl Parser {
 
         if is_table {
             let header = items.remove(0);
+            self.compiler.tables.push(Table::new(header, items));
             self.create_node(
-                AstNode::Table {
-                    header,
-                    rows: items,
-                },
+                AstNode::Table(TableId(self.compiler.tables.len() - 1)),
                 span_start,
                 span_end,
             )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,6 +34,12 @@ pub struct TableId(pub usize);
 pub struct RecordId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MatchId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TypeArgsId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -114,6 +120,29 @@ impl Record {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct Match {
+    pub target: NodeId,
+    pub match_arms: Vec<(NodeId, NodeId)>,
+}
+
+impl Match {
+    pub fn new(target: NodeId, match_arms: Vec<(NodeId, NodeId)>) -> Self {
+        Self { target, match_arms }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeArgs {
+    pub args: Vec<NodeId>,
+}
+
+impl TypeArgs {
+    pub fn new(args: Vec<NodeId>) -> Self {
+        Self { args }
+    }
+}
+
 // Pipeline just contains a list of expressions
 //
 // It's not allowed if there is only one element in pipeline, in that
@@ -181,8 +210,7 @@ impl AssignmentOrExpression {
     }
 }
 
-// TODO: All nodes with Vec<...> should be moved to their own ID (like BlockId) to allow Copy trait
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum AstNode {
     Int,
     Float,
@@ -193,7 +221,7 @@ pub enum AstNode {
         args: Option<NodeId>,
         optional: bool,
     },
-    TypeArgs(Vec<NodeId>),
+    TypeArgs(TypeArgsId),
     RecordType {
         /// Contains [AstNode::Params]
         fields: NodeId,
@@ -333,10 +361,7 @@ pub enum AstNode {
         catch_block: Option<NodeId>,
         finally_block: Option<NodeId>,
     },
-    Match {
-        target: NodeId,
-        match_arms: Vec<(NodeId, NodeId)>,
-    },
+    Match(MatchId),
     Statement(NodeId),
     Garbage,
 }
@@ -1000,7 +1025,12 @@ impl Parser {
             }
         }
 
-        self.create_node(AstNode::Match { target, match_arms }, span_start, span_end)
+        self.compiler.matches.push(Match::new(target, match_arms));
+        self.create_node(
+            AstNode::Match(MatchId(self.compiler.matches.len() - 1)),
+            span_start,
+            span_end,
+        )
     }
 
     pub fn if_expression(&mut self) -> NodeId {
@@ -1233,7 +1263,12 @@ impl Parser {
             output
         };
 
-        self.create_node(AstNode::TypeArgs(arg_list), span_start, span_end)
+        self.compiler.type_args.push(TypeArgs::new(arg_list));
+        self.create_node(
+            AstNode::TypeArgs(TypeArgsId(self.compiler.type_args.len() - 1)),
+            span_start,
+            span_end,
+        )
     }
 
     pub fn typename(&mut self) -> NodeId {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,6 +25,9 @@ pub struct InOutTypesId(pub usize);
 pub struct CallId(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ListId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PipelineId(pub usize);
 
 #[derive(Debug, Clone)]
@@ -68,6 +71,17 @@ pub struct Call {
 impl Call {
     pub fn new(parts: Vec<NodeId>) -> Self {
         Self { parts }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct List {
+    pub items: Vec<NodeId>,
+}
+
+impl List {
+    pub fn new(items: Vec<NodeId>) -> Self {
+        Self { items }
     }
 }
 
@@ -271,7 +285,7 @@ pub enum AstNode {
         lhs: NodeId,
         rhs: NodeId,
     },
-    List(Vec<NodeId>),
+    List(ListId),
     Table {
         header: NodeId,
         rows: Vec<NodeId>,
@@ -742,7 +756,12 @@ impl Parser {
                 span_end,
             )
         } else {
-            self.create_node(AstNode::List(items), span_start, span_end)
+            self.compiler.lists.push(List::new(items));
+            self.create_node(
+                AstNode::List(ListId(self.compiler.lists.len() - 1)),
+                span_start,
+                span_end,
+            )
         }
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -271,10 +271,8 @@ impl<'a> Resolver<'a> {
                 // making sure the def parameters and body end up in the same scope frame
                 self.enter_scope(block);
                 if let Some(type_params) = type_params {
-                    let AstNode::Params(type_params) = self.compiler.get_node(type_params) else {
-                        panic!("Internal error: expected type params")
-                    };
-                    for type_param_id in type_params {
+                    let type_params = self.compiler.get_params(type_params);
+                    for type_param_id in &type_params.nodes {
                         self.define_type_decl(*type_param_id, TypeDecl::Param(*type_param_id));
                     }
                 }
@@ -292,8 +290,9 @@ impl<'a> Resolver<'a> {
             } => {
                 self.define_decl(new_name, node_id);
             }
-            AstNode::Params(ref params) => {
-                for param in params {
+            AstNode::Params(_) => {
+                let params = self.compiler.get_params(node_id);
+                for param in &params.nodes {
                     let AstNode::Param { name, ty } = self.compiler.ast_nodes[param.0] else {
                         panic!("param is not a param");
                     };
@@ -394,10 +393,8 @@ impl<'a> Resolver<'a> {
                 }
             }
             AstNode::RecordType { fields, .. } => {
-                let AstNode::Params(fields) = self.compiler.get_node(fields) else {
-                    panic!("Internal error: expected params for record field types");
-                };
-                for field in fields {
+                let fields = self.compiler.get_params(fields);
+                for field in &fields.nodes {
                     if let AstNode::Param { ty: Some(ty), .. } = self.compiler.get_node(*field) {
                         self.resolve_node(*ty);
                     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -242,7 +242,10 @@ impl<'a> Resolver<'a> {
         // TODO: Move node_id param to the end, same as in typechecker
         match self.compiler.ast_nodes[node_id.0] {
             AstNode::Variable => self.resolve_variable(node_id),
-            AstNode::Call { ref parts } => self.resolve_call(node_id, parts),
+            AstNode::Call(_) => {
+                let parts = self.compiler.get_call(node_id).parts.clone();
+                self.resolve_call(node_id, &parts)
+            }
             AstNode::Block(_) => self.resolve_block(node_id, None),
             AstNode::Closure { params, block } => {
                 // making sure the closure parameters and body end up in the same scope frame

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -358,8 +358,8 @@ impl<'a> Resolver<'a> {
                     self.resolve_node(*row);
                 }
             }
-            AstNode::Record { ref pairs } => {
-                for (key, val) in pairs {
+            AstNode::Record(_) => {
+                for (key, val) in &self.compiler.get_record(node_id).pairs {
                     self.resolve_node(*key);
                     self.resolve_node(*val);
                 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -346,8 +346,8 @@ impl<'a> Resolver<'a> {
                 self.resolve_node(lhs);
                 self.resolve_node(rhs);
             }
-            AstNode::List(ref nodes) => {
-                for node in nodes {
+            AstNode::List(_) => {
+                for node in &self.compiler.get_list(node_id).items {
                     self.resolve_node(*node);
                 }
             }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -405,8 +405,8 @@ impl<'a> Resolver<'a> {
                     self.resolve_node(*arg);
                 }
             }
-            AstNode::InOutTypes(ref in_out_types) => {
-                for in_out_ty in in_out_types {
+            AstNode::InOutTypes(_) => {
+                for in_out_ty in &self.compiler.get_in_out_types(node_id).nodes {
                     self.resolve_node(*in_out_ty);
                 }
             }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -379,12 +379,10 @@ impl<'a> Resolver<'a> {
                     self.resolve_node(block);
                 }
             }
-            AstNode::Match {
-                target,
-                ref match_arms,
-            } => {
-                self.resolve_node(target);
-                for (arm_lhs, arm_rhs) in match_arms {
+            AstNode::Match(_) => {
+                let match_node = self.compiler.get_match(node_id);
+                self.resolve_node(match_node.target);
+                for (arm_lhs, arm_rhs) in &match_node.match_arms {
                     self.resolve_node(*arm_lhs);
                     self.resolve_node(*arm_rhs);
                 }
@@ -404,8 +402,8 @@ impl<'a> Resolver<'a> {
                     }
                 }
             }
-            AstNode::TypeArgs(ref args) => {
-                for arg in args {
+            AstNode::TypeArgs(_) => {
+                for arg in &self.compiler.get_type_args(node_id).args {
                     self.resolve_node(*arg);
                 }
             }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -351,9 +351,10 @@ impl<'a> Resolver<'a> {
                     self.resolve_node(*node);
                 }
             }
-            AstNode::Table { header, ref rows } => {
-                self.resolve_node(header);
-                for row in rows {
+            AstNode::Table(_) => {
+                let table = self.compiler.get_table(node_id);
+                self.resolve_node(table.header);
+                for row in &table.rows {
                     self.resolve_node(*row);
                 }
             }

--- a/src/snapshots/new_nu_parser__test__node_output@alias.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@alias.nu.snap
@@ -1,8 +1,8 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/alias.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (6 to 19) ""fancy alias""
@@ -10,7 +10,7 @@ snapshot_kind: text
 2: Alias { new_name: NodeId(0), old_name: NodeId(1) } (0 to 25)
 3: Name (27 to 32) "fancy"
 4: Name (33 to 38) "alias"
-5: Call { parts: [NodeId(3), NodeId(4)] } (33 to 38)
+5: Call(CallId(0)) (33 to 38)
 6: Block(BlockId(0)) (0 to 39)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6)
@@ -28,3 +28,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Alias { new_name: NodeId(0), old_name: NodeId(1) } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/binary_ops_exact.nu
 ---
@@ -9,10 +10,10 @@ input_file: tests/binary_ops_exact.nu
 2: Int (5 to 6) "1"
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 6)
 4: True (8 to 12)
-5: List([NodeId(4)]) (7 to 12)
+5: List(ListId(0)) (7 to 12)
 6: Append (14 to 16)
 7: False (18 to 23)
-8: List([NodeId(7)]) (17 to 23)
+8: List(ListId(1)) (17 to 23)
 9: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(8) } (7 to 23)
 10: Int (25 to 26) "1"
 11: Plus (27 to 28)
@@ -34,7 +35,7 @@ input_file: tests/binary_ops_exact.nu
 27: In (73 to 75)
 28: Int (77 to 78) "1"
 29: Int (80 to 81) "2"
-30: List([NodeId(28), NodeId(29)]) (76 to 81)
+30: List(ListId(2)) (76 to 81)
 31: BinaryOp { lhs: NodeId(26), op: NodeId(27), rhs: NodeId(30) } (71 to 81)
 32: Block(BlockId(0)) (0 to 83)
 ==== SCOPE ====
@@ -80,3 +81,4 @@ file_count: 0
 1: LoadLiteral { dst: RegId(1), lit: Int(1) }
 ==== IR ERRORS ====
 Error (NodeId 1): unrecognized operator Equal
+

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/binary_ops_subtypes.nu
 ---
@@ -17,43 +18,43 @@ input_file: tests/binary_ops_subtypes.nu
 10: Float (24 to 27) "1.0"
 11: BinaryOp { lhs: NodeId(8), op: NodeId(9), rhs: NodeId(10) } (20 to 27)
 12: Int (29 to 30) "1"
-13: List([NodeId(12)]) (28 to 30)
+13: List(ListId(0)) (28 to 30)
 14: Append (32 to 34)
 15: Float (36 to 39) "1.0"
-16: List([NodeId(15)]) (35 to 39)
+16: List(ListId(1)) (35 to 39)
 17: BinaryOp { lhs: NodeId(13), op: NodeId(14), rhs: NodeId(16) } (28 to 39)
 18: Float (42 to 45) "1.0"
 19: Int (46 to 47) "1"
-20: List([NodeId(18), NodeId(19)]) (41 to 47)
+20: List(ListId(2)) (41 to 47)
 21: Append (49 to 51)
 22: String (53 to 56) ""a""
-23: List([NodeId(22)]) (52 to 56)
+23: List(ListId(3)) (52 to 56)
 24: BinaryOp { lhs: NodeId(20), op: NodeId(21), rhs: NodeId(23) } (41 to 56)
 25: Int (60 to 61) "1"
-26: List([NodeId(25)]) (59 to 61)
+26: List(ListId(4)) (59 to 61)
 27: Int (64 to 65) "2"
-28: List([NodeId(27)]) (63 to 65)
-29: List([NodeId(26), NodeId(28)]) (58 to 66)
+28: List(ListId(5)) (63 to 65)
+29: List(ListId(6)) (58 to 66)
 30: Append (68 to 70)
 31: Int (73 to 74) "3"
-32: List([NodeId(31)]) (72 to 74)
-33: List([NodeId(32)]) (71 to 75)
+32: List(ListId(7)) (72 to 74)
+33: List(ListId(8)) (71 to 75)
 34: BinaryOp { lhs: NodeId(29), op: NodeId(30), rhs: NodeId(33) } (58 to 75)
 35: Int (79 to 80) "1"
-36: List([NodeId(35)]) (78 to 80)
+36: List(ListId(9)) (78 to 80)
 37: Int (83 to 84) "2"
-38: List([NodeId(37)]) (82 to 84)
-39: List([NodeId(36), NodeId(38)]) (77 to 85)
+38: List(ListId(10)) (82 to 84)
+39: List(ListId(11)) (77 to 85)
 40: Append (87 to 89)
 41: Float (92 to 95) "3.0"
-42: List([NodeId(41)]) (91 to 95)
-43: List([NodeId(42)]) (90 to 96)
+42: List(ListId(12)) (91 to 95)
+43: List(ListId(13)) (90 to 96)
 44: BinaryOp { lhs: NodeId(39), op: NodeId(40), rhs: NodeId(43) } (77 to 96)
 45: Int (98 to 99) "1"
 46: In (100 to 102)
 47: Float (104 to 107) "1.0"
 48: Int (109 to 110) "1"
-49: List([NodeId(47), NodeId(48)]) (103 to 110)
+49: List(ListId(14)) (103 to 110)
 50: BinaryOp { lhs: NodeId(45), op: NodeId(46), rhs: NodeId(49) } (98 to 110)
 51: Float (112 to 115) "2.3"
 52: Modulo (116 to 119)
@@ -64,7 +65,7 @@ input_file: tests/binary_ops_subtypes.nu
 57: String (130 to 131) "c"
 58: Int (133 to 134) "3"
 59: Record { pairs: [(NodeId(55), NodeId(56)), (NodeId(57), NodeId(58))] } (123 to 135)
-60: List([NodeId(59)]) (122 to 135)
+60: List(ListId(15)) (122 to 135)
 61: Append (137 to 139)
 62: String (142 to 143) "a"
 63: Int (145 to 146) "3"
@@ -73,7 +74,7 @@ input_file: tests/binary_ops_subtypes.nu
 66: String (156 to 157) "c"
 67: String (159 to 164) ""foo""
 68: Record { pairs: [(NodeId(62), NodeId(63)), (NodeId(64), NodeId(65)), (NodeId(66), NodeId(67))] } (141 to 165)
-69: List([NodeId(68)]) (140 to 165)
+69: List(ListId(16)) (140 to 165)
 70: BinaryOp { lhs: NodeId(60), op: NodeId(61), rhs: NodeId(69) } (122 to 165)
 71: Block(BlockId(0)) (0 to 167)
 ==== SCOPE ====
@@ -159,3 +160,4 @@ file_count: 0
 0: LoadLiteral { dst: RegId(0), lit: Int(1) }
 ==== IR ERRORS ====
 Error (NodeId 2): node Float not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
@@ -64,7 +64,7 @@ input_file: tests/binary_ops_subtypes.nu
 56: Int (127 to 128) "2"
 57: String (130 to 131) "c"
 58: Int (133 to 134) "3"
-59: Record { pairs: [(NodeId(55), NodeId(56)), (NodeId(57), NodeId(58))] } (123 to 135)
+59: Record(RecordId(0)) (123 to 135)
 60: List(ListId(15)) (122 to 135)
 61: Append (137 to 139)
 62: String (142 to 143) "a"
@@ -73,7 +73,7 @@ input_file: tests/binary_ops_subtypes.nu
 65: Float (151 to 154) "1.5"
 66: String (156 to 157) "c"
 67: String (159 to 164) ""foo""
-68: Record { pairs: [(NodeId(62), NodeId(63)), (NodeId(64), NodeId(65)), (NodeId(66), NodeId(67))] } (141 to 165)
+68: Record(RecordId(1)) (141 to 165)
 69: List(ListId(16)) (140 to 165)
 70: BinaryOp { lhs: NodeId(60), op: NodeId(61), rhs: NodeId(69) } (122 to 165)
 71: Block(BlockId(0)) (0 to 167)

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -12,7 +12,7 @@ input_file: tests/calls.nu
 4: Plus (18 to 19)
 5: Int (20 to 21) "2"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 21)
-7: Call { parts: [NodeId(0), NodeId(1), NodeId(2), NodeId(6)] } (5 to 22)
+7: Call(CallId(0)) (5 to 22)
 8: Name (28 to 36) "existing"
 9: Name (38 to 39) "a"
 10: Name (41 to 47) "string"
@@ -40,10 +40,10 @@ input_file: tests/calls.nu
 32: String (107 to 110) ""r""
 33: BinaryOp { lhs: NodeId(30), op: NodeId(31), rhs: NodeId(32) } (100 to 110)
 34: Int (112 to 113) "3"
-35: Call { parts: [NodeId(28), NodeId(29), NodeId(33), NodeId(34)] } (95 to 113)
+35: Call(CallId(1)) (95 to 113)
 36: Name (115 to 128) "foo/bar/spam
 "
-37: Call { parts: [NodeId(36)] } (127 to 127)
+37: Call(CallId(2)) (127 to 127)
 38: Block(BlockId(1)) (0 to 128)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(38)
@@ -94,5 +94,5 @@ input_file: tests/calls.nu
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 7): node Call { parts: [NodeId(0), NodeId(1), NodeId(2), NodeId(6)] } not suported yet
+Error (NodeId 7): node Call(CallId(0)) not suported yet
 

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/calls.nu
 ---
@@ -25,7 +26,7 @@ input_file: tests/calls.nu
 18: Name (63 to 66) "int"
 19: Type { name: NodeId(18), args: None, optional: false } (63 to 66)
 20: Param { name: NodeId(17), ty: Some(NodeId(19)) } (60 to 66)
-21: Params([NodeId(12), NodeId(16), NodeId(20)]) (37 to 67)
+21: Params(ParamsId(0)) (37 to 67)
 22: Variable (72 to 74) "$a"
 23: Variable (76 to 78) "$b"
 24: Variable (80 to 82) "$c"
@@ -94,3 +95,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 7): node Call { parts: [NodeId(0), NodeId(1), NodeId(2), NodeId(6)] } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -30,7 +30,7 @@ input_file: tests/calls.nu
 22: Variable (72 to 74) "$a"
 23: Variable (76 to 78) "$b"
 24: Variable (80 to 82) "$c"
-25: List([NodeId(22), NodeId(23), NodeId(24)]) (70 to 82)
+25: List(ListId(0)) (70 to 82)
 26: Block(BlockId(0)) (68 to 85)
 27: Def { name: NodeId(8), type_params: None, params: NodeId(21), in_out_types: None, block: NodeId(26), env: false, wrapped: false } (24 to 85)
 28: Name (86 to 94) "existing"

--- a/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/calls_invalid.nu
 ---
@@ -9,7 +10,7 @@ input_file: tests/calls_invalid.nu
 2: Name (13 to 16) "int"
 3: Type { name: NodeId(2), args: None, optional: false } (13 to 16)
 4: Param { name: NodeId(1), ty: Some(NodeId(3)) } (10 to 16)
-5: Params([NodeId(4)]) (8 to 18)
+5: Params(ParamsId(0)) (8 to 18)
 6: Block(BlockId(0)) (19 to 21)
 7: Def { name: NodeId(0), type_params: None, params: NodeId(5), in_out_types: None, block: NodeId(6), env: false, wrapped: false } (0 to 21)
 8: Name (22 to 25) "foo"
@@ -50,3 +51,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 7): node Def { name: NodeId(0), type_params: None, params: NodeId(5), in_out_types: None, block: NodeId(6), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
@@ -16,10 +16,10 @@ input_file: tests/calls_invalid.nu
 8: Name (22 to 25) "foo"
 9: Int (26 to 27) "1"
 10: Int (28 to 29) "2"
-11: Call { parts: [NodeId(8), NodeId(9), NodeId(10)] } (26 to 29)
+11: Call(CallId(0)) (26 to 29)
 12: Name (30 to 33) "foo"
 13: String (34 to 42) ""string""
-14: Call { parts: [NodeId(12), NodeId(13)] } (34 to 42)
+14: Call(CallId(1)) (34 to 42)
 15: Block(BlockId(1)) (0 to 43)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(15)

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -1,15 +1,15 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/closure.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Name (3 to 4) "a"
 1: Param { name: NodeId(0), ty: None } (3 to 4)
 2: Name (6 to 7) "b"
 3: Param { name: NodeId(2), ty: None } (6 to 7)
-4: Params([NodeId(1), NodeId(3)]) (2 to 8)
+4: Params(ParamsId(0)) (2 to 8)
 5: Variable (9 to 11) "$a"
 6: Plus (12 to 13)
 7: Variable (14 to 16) "$b"
@@ -24,3 +24,4 @@ snapshot_kind: text
   variables: [ a: NodeId(0), b: NodeId(2) ]
 ==== SCOPE ERRORS ====
 Error (NodeId 11): variable `a` not found
+

--- a/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
@@ -27,7 +27,7 @@ input_file: tests/closure3.nu
 19: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(18), is_mutable: false } (0 to 44)
 20: Name (46 to 52) "filter"
 21: Variable (53 to 61) "$closure"
-22: Call { parts: [NodeId(20), NodeId(21)] } (53 to 61)
+22: Call(CallId(0)) (53 to 61)
 23: Block(BlockId(1)) (0 to 62)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(23)

--- a/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/closure3.nu
 ---
@@ -13,7 +14,7 @@ input_file: tests/closure3.nu
 6: Name (27 to 30) "int"
 7: Type { name: NodeId(6), args: None, optional: false } (27 to 30)
 8: Param { name: NodeId(5), ty: Some(NodeId(7)) } (24 to 30)
-9: Params([NodeId(4), NodeId(8)]) (15 to 31)
+9: Params(ParamsId(0)) (15 to 31)
 10: Variable (32 to 34) "$a"
 11: Plus (35 to 36)
 12: Variable (37 to 39) "$b"
@@ -63,3 +64,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 19): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(18), is_mutable: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
@@ -17,9 +17,9 @@ input_file: tests/def.nu
 9: Name (27 to 31) "list"
 10: Name (32 to 35) "int"
 11: Type { name: NodeId(10), args: None, optional: false } (32 to 35)
-12: TypeArgs([NodeId(11)]) (31 to 36)
+12: TypeArgs(TypeArgsId(0)) (31 to 36)
 13: Type { name: NodeId(9), args: Some(NodeId(12)), optional: false } (27 to 31)
-14: TypeArgs([NodeId(13)]) (26 to 37)
+14: TypeArgs(TypeArgsId(1)) (26 to 37)
 15: Type { name: NodeId(8), args: Some(NodeId(14)), optional: false } (22 to 26)
 16: Param { name: NodeId(7), ty: Some(NodeId(15)) } (19 to 26)
 17: Name (39 to 40) "z"

--- a/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
@@ -38,7 +38,7 @@ input_file: tests/def.nu
 30: Variable (69 to 71) "$x"
 31: Variable (73 to 75) "$y"
 32: Variable (77 to 79) "$z"
-33: List([NodeId(29), NodeId(30), NodeId(31), NodeId(32)]) (64 to 80)
+33: List(ListId(0)) (64 to 80)
 34: Block(BlockId(0)) (62 to 83)
 35: Def { name: NodeId(0), type_params: None, params: NodeId(28), in_out_types: None, block: NodeId(34), env: false, wrapped: false } (0 to 83)
 36: Block(BlockId(1)) (0 to 83)

--- a/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def.nu
 ---
@@ -29,10 +30,10 @@ input_file: tests/def.nu
 22: Name (55 to 58) "int"
 23: Type { name: NodeId(22), args: None, optional: false } (55 to 58)
 24: Param { name: NodeId(21), ty: Some(NodeId(23)) } (52 to 58)
-25: Params([NodeId(20), NodeId(24)]) (48 to 59)
+25: Params(ParamsId(0)) (48 to 59)
 26: RecordType { fields: NodeId(25), optional: false } (42 to 60)
 27: Param { name: NodeId(17), ty: Some(NodeId(26)) } (39 to 60)
-28: Params([NodeId(2), NodeId(6), NodeId(16), NodeId(27)]) (8 to 61)
+28: Params(ParamsId(1)) (8 to 61)
 29: Variable (66 to 68) "$w"
 30: Variable (69 to 71) "$x"
 31: Variable (73 to 75) "$y"
@@ -89,3 +90,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 35): node Def { name: NodeId(0), type_params: None, params: NodeId(28), in_out_types: None, block: NodeId(34), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
@@ -16,7 +16,7 @@ input_file: tests/def_return_type.nu
 8: Type { name: NodeId(4), args: Some(NodeId(7)), optional: false } (25 to 29)
 9: InOutType(NodeId(3), NodeId(8)) (14 to 35)
 10: InOutTypes(InOutTypesId(0)) (14 to 35)
-11: List([]) (37 to 38)
+11: List(ListId(0)) (37 to 38)
 12: Block(BlockId(0)) (35 to 41)
 13: Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12), env: false, wrapped: false } (0 to 41)
 14: Name (46 to 49) "bar"
@@ -38,7 +38,7 @@ input_file: tests/def_return_type.nu
 30: Type { name: NodeId(26), args: Some(NodeId(29)), optional: false } (89 to 93)
 31: InOutType(NodeId(25), NodeId(30)) (82 to 99)
 32: InOutTypes(InOutTypesId(1)) (56 to 101)
-33: List([]) (103 to 104)
+33: List(ListId(1)) (103 to 104)
 34: Block(BlockId(1)) (101 to 107)
 35: Def { name: NodeId(14), type_params: None, params: NodeId(15), in_out_types: Some(NodeId(32)), block: NodeId(34), env: false, wrapped: false } (42 to 107)
 36: Block(BlockId(2)) (0 to 108)

--- a/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
@@ -12,7 +12,7 @@ input_file: tests/def_return_type.nu
 4: Name (25 to 29) "list"
 5: Name (30 to 33) "any"
 6: Type { name: NodeId(5), args: None, optional: false } (30 to 33)
-7: TypeArgs([NodeId(6)]) (29 to 34)
+7: TypeArgs(TypeArgsId(0)) (29 to 34)
 8: Type { name: NodeId(4), args: Some(NodeId(7)), optional: false } (25 to 29)
 9: InOutType(NodeId(3), NodeId(8)) (14 to 35)
 10: InOutTypes(InOutTypesId(0)) (14 to 35)
@@ -26,7 +26,7 @@ input_file: tests/def_return_type.nu
 18: Name (68 to 72) "list"
 19: Name (73 to 79) "string"
 20: Type { name: NodeId(19), args: None, optional: false } (73 to 79)
-21: TypeArgs([NodeId(20)]) (72 to 80)
+21: TypeArgs(TypeArgsId(1)) (72 to 80)
 22: Type { name: NodeId(18), args: Some(NodeId(21)), optional: false } (68 to 72)
 23: InOutType(NodeId(17), NodeId(22)) (58 to 80)
 24: Name (82 to 85) "int"
@@ -34,7 +34,7 @@ input_file: tests/def_return_type.nu
 26: Name (89 to 93) "list"
 27: Name (94 to 97) "int"
 28: Type { name: NodeId(27), args: None, optional: false } (94 to 97)
-29: TypeArgs([NodeId(28)]) (93 to 98)
+29: TypeArgs(TypeArgsId(2)) (93 to 98)
 30: Type { name: NodeId(26), args: Some(NodeId(29)), optional: false } (89 to 93)
 31: InOutType(NodeId(25), NodeId(30)) (82 to 99)
 32: InOutTypes(InOutTypesId(1)) (56 to 101)

--- a/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
@@ -1,11 +1,12 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def_return_type.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 7) "foo"
-1: Params([]) (8 to 11)
+1: Params(ParamsId(0)) (8 to 11)
 2: Name (14 to 21) "nothing"
 3: Type { name: NodeId(2), args: None, optional: false } (14 to 21)
 4: Name (25 to 29) "list"
@@ -14,12 +15,12 @@ input_file: tests/def_return_type.nu
 7: TypeArgs([NodeId(6)]) (29 to 34)
 8: Type { name: NodeId(4), args: Some(NodeId(7)), optional: false } (25 to 29)
 9: InOutType(NodeId(3), NodeId(8)) (14 to 35)
-10: InOutTypes([NodeId(9)]) (14 to 35)
+10: InOutTypes(InOutTypesId(0)) (14 to 35)
 11: List([]) (37 to 38)
 12: Block(BlockId(0)) (35 to 41)
 13: Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12), env: false, wrapped: false } (0 to 41)
 14: Name (46 to 49) "bar"
-15: Params([]) (50 to 53)
+15: Params(ParamsId(1)) (50 to 53)
 16: Name (58 to 64) "string"
 17: Type { name: NodeId(16), args: None, optional: false } (58 to 64)
 18: Name (68 to 72) "list"
@@ -36,7 +37,7 @@ input_file: tests/def_return_type.nu
 29: TypeArgs([NodeId(28)]) (93 to 98)
 30: Type { name: NodeId(26), args: Some(NodeId(29)), optional: false } (89 to 93)
 31: InOutType(NodeId(25), NodeId(30)) (82 to 99)
-32: InOutTypes([NodeId(23), NodeId(31)]) (56 to 101)
+32: InOutTypes(InOutTypesId(1)) (56 to 101)
 33: List([]) (103 to 104)
 34: Block(BlockId(1)) (101 to 107)
 35: Def { name: NodeId(14), type_params: None, params: NodeId(15), in_out_types: Some(NodeId(32)), block: NodeId(34), env: false, wrapped: false } (42 to 107)
@@ -89,3 +90,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 13): node Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@def_with_flags.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_with_flags.nu.snap
@@ -1,21 +1,22 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def_with_flags.nu
 ---
 ==== COMPILER ====
 0: Name (10 to 13) "foo"
-1: Params([]) (14 to 17)
+1: Params(ParamsId(0)) (14 to 17)
 2: String (20 to 25) ""foo""
 3: Block(BlockId(0)) (18 to 27)
 4: Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: None, block: NodeId(3), env: true, wrapped: false } (0 to 27)
 5: Name (42 to 46) "foo2"
-6: Params([]) (47 to 50)
+6: Params(ParamsId(1)) (47 to 50)
 7: String (53 to 59) ""foo2""
 8: Block(BlockId(1)) (51 to 61)
 9: Def { name: NodeId(5), type_params: None, params: NodeId(6), in_out_types: None, block: NodeId(8), env: false, wrapped: true } (28 to 61)
 10: Name (82 to 86) "foo3"
-11: Params([]) (87 to 90)
+11: Params(ParamsId(2)) (87 to 90)
 12: String (93 to 99) ""foo3""
 13: Block(BlockId(2)) (91 to 101)
 14: Def { name: NodeId(10), type_params: None, params: NodeId(11), in_out_types: None, block: NodeId(13), env: true, wrapped: true } (62 to 101)
@@ -48,3 +49,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 4): node Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: None, block: NodeId(3), env: true, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@extern.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@extern.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/extern.nu
 ---
@@ -9,7 +10,7 @@ input_file: tests/extern.nu
 2: Name (19 to 25) "string"
 3: Type { name: NodeId(2), args: None, optional: false } (19 to 25)
 4: Param { name: NodeId(1), ty: Some(NodeId(3)) } (13 to 25)
-5: Params([NodeId(4)]) (12 to 26)
+5: Params(ParamsId(0)) (12 to 26)
 6: Extern { name: NodeId(0), params: NodeId(5) } (0 to 26)
 7: Block(BlockId(0)) (0 to 27)
 ==== SCOPE ====
@@ -30,3 +31,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 6): node Extern { name: NodeId(0), params: NodeId(5) } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -1,8 +1,8 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/for.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -12,7 +12,7 @@ snapshot_kind: text
 4: Int (20 to 21) "1"
 5: Int (22 to 23) "2"
 6: Int (24 to 25) "3"
-7: List([NodeId(4), NodeId(5), NodeId(6)]) (19 to 25)
+7: List(ListId(0)) (19 to 25)
 8: Variable (33 to 35) "$x"
 9: Assignment (36 to 37)
 10: Variable (38 to 40) "$x"
@@ -26,7 +26,7 @@ snapshot_kind: text
 18: Int (60 to 61) "4"
 19: Int (62 to 63) "5"
 20: Int (64 to 65) "6"
-21: List([NodeId(18), NodeId(19), NodeId(20)]) (59 to 65)
+21: List(ListId(1)) (59 to 65)
 22: Variable (73 to 75) "$x"
 23: Assignment (76 to 77)
 24: Variable (78 to 80) "$x"
@@ -82,3 +82,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/for_break_continue.nu
 ---
@@ -11,7 +12,7 @@ input_file: tests/for_break_continue.nu
 4: Int (20 to 21) "1"
 5: Int (22 to 23) "2"
 6: Int (24 to 25) "3"
-7: List([NodeId(4), NodeId(5), NodeId(6)]) (19 to 25)
+7: List(ListId(0)) (19 to 25)
 8: Variable (36 to 38) "$x"
 9: GreaterThan (39 to 40)
 10: Int (41 to 42) "2"
@@ -81,3 +82,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
@@ -73,7 +73,7 @@ input_file: tests/infer_complex.nu
 65: Variable (154 to 155) "m"
 66: Name (158 to 168) "mysterious"
 67: Int (169 to 170) "0"
-68: Call { parts: [NodeId(66), NodeId(67)] } (169 to 170)
+68: Call(CallId(0)) (169 to 170)
 69: Let { variable_name: NodeId(65), ty: None, initializer: NodeId(68), is_mutable: false } (150 to 170)
 70: Variable (175 to 176) "a"
 71: Name (178 to 184) "record"
@@ -94,7 +94,7 @@ input_file: tests/infer_complex.nu
 86: String (229 to 230) "b"
 87: String (232 to 237) ""foo""
 88: Record { pairs: [(NodeId(84), NodeId(85)), (NodeId(86), NodeId(87))] } (218 to 239)
-89: Call { parts: [NodeId(78), NodeId(83), NodeId(88)] } (200 to 239)
+89: Call(CallId(1)) (200 to 239)
 90: Let { variable_name: NodeId(70), ty: Some(NodeId(77)), initializer: NodeId(89), is_mutable: false } (171 to 239)
 91: Block(BlockId(2)) (0 to 240)
 ==== SCOPE ====

--- a/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_complex.nu
 ---
@@ -7,7 +8,7 @@ input_file: tests/infer_complex.nu
 0: Name (4 to 5) "f"
 1: Name (6 to 7) "A"
 2: Name (9 to 10) "B"
-3: Params([NodeId(1), NodeId(2)]) (5 to 11)
+3: Params(ParamsId(0)) (5 to 11)
 4: Name (14 to 15) "x"
 5: Name (17 to 23) "record"
 6: Name (24 to 25) "a"
@@ -18,7 +19,7 @@ input_file: tests/infer_complex.nu
 11: Name (33 to 34) "B"
 12: Type { name: NodeId(11), args: None, optional: false } (33 to 34)
 13: Param { name: NodeId(10), ty: Some(NodeId(12)) } (30 to 34)
-14: Params([NodeId(9), NodeId(13)]) (23 to 35)
+14: Params(ParamsId(1)) (23 to 35)
 15: RecordType { fields: NodeId(14), optional: false } (17 to 35)
 16: Param { name: NodeId(4), ty: Some(NodeId(15)) } (14 to 35)
 17: Name (37 to 38) "y"
@@ -31,10 +32,10 @@ input_file: tests/infer_complex.nu
 24: Name (56 to 57) "B"
 25: Type { name: NodeId(24), args: None, optional: false } (56 to 57)
 26: Param { name: NodeId(23), ty: Some(NodeId(25)) } (53 to 57)
-27: Params([NodeId(22), NodeId(26)]) (46 to 58)
+27: Params(ParamsId(2)) (46 to 58)
 28: RecordType { fields: NodeId(27), optional: false } (40 to 59)
 29: Param { name: NodeId(17), ty: Some(NodeId(28)) } (37 to 59)
-30: Params([NodeId(16), NodeId(29)]) (12 to 60)
+30: Params(ParamsId(3)) (12 to 60)
 31: Name (63 to 70) "nothing"
 32: Type { name: NodeId(31), args: None, optional: false } (63 to 70)
 33: Name (74 to 80) "record"
@@ -46,27 +47,27 @@ input_file: tests/infer_complex.nu
 39: Name (90 to 91) "B"
 40: Type { name: NodeId(39), args: None, optional: false } (90 to 91)
 41: Param { name: NodeId(38), ty: Some(NodeId(40)) } (87 to 91)
-42: Params([NodeId(37), NodeId(41)]) (80 to 92)
+42: Params(ParamsId(4)) (80 to 92)
 43: RecordType { fields: NodeId(42), optional: false } (74 to 93)
 44: InOutType(NodeId(32), NodeId(43)) (63 to 93)
-45: InOutTypes([NodeId(44)]) (63 to 93)
+45: InOutTypes(InOutTypesId(0)) (63 to 93)
 46: Variable (97 to 99) "$x"
 47: Block(BlockId(0)) (93 to 101)
 48: Def { name: NodeId(0), type_params: Some(NodeId(3)), params: NodeId(30), in_out_types: Some(NodeId(45)), block: NodeId(47), env: false, wrapped: false } (0 to 101)
 49: Name (106 to 116) "mysterious"
 50: Name (117 to 118) "T"
-51: Params([NodeId(50)]) (116 to 119)
+51: Params(ParamsId(5)) (116 to 119)
 52: Name (122 to 123) "x"
 53: Name (125 to 128) "int"
 54: Type { name: NodeId(53), args: None, optional: false } (125 to 128)
 55: Param { name: NodeId(52), ty: Some(NodeId(54)) } (122 to 128)
-56: Params([NodeId(55)]) (120 to 130)
+56: Params(ParamsId(6)) (120 to 130)
 57: Name (133 to 140) "nothing"
 58: Type { name: NodeId(57), args: None, optional: false } (133 to 140)
 59: Name (144 to 145) "T"
 60: Type { name: NodeId(59), args: None, optional: false } (144 to 145)
 61: InOutType(NodeId(58), NodeId(60)) (133 to 146)
-62: InOutTypes([NodeId(61)]) (133 to 146)
+62: InOutTypes(InOutTypesId(1)) (133 to 146)
 63: Block(BlockId(1)) (146 to 148)
 64: Def { name: NodeId(49), type_params: Some(NodeId(51)), params: NodeId(56), in_out_types: Some(NodeId(62)), block: NodeId(63), env: false, wrapped: false } (102 to 148)
 65: Variable (154 to 155) "m"
@@ -80,7 +81,7 @@ input_file: tests/infer_complex.nu
 73: Name (188 to 194) "number"
 74: Type { name: NodeId(73), args: None, optional: false } (188 to 194)
 75: Param { name: NodeId(72), ty: Some(NodeId(74)) } (185 to 194)
-76: Params([NodeId(75)]) (184 to 195)
+76: Params(ParamsId(7)) (184 to 195)
 77: RecordType { fields: NodeId(76), optional: false } (178 to 196)
 78: Name (198 to 199) "f"
 79: String (202 to 203) "a"
@@ -204,3 +205,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 48): node Def { name: NodeId(0), type_params: Some(NodeId(3)), params: NodeId(30), in_out_types: Some(NodeId(45)), block: NodeId(47), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
@@ -88,12 +88,12 @@ input_file: tests/infer_complex.nu
 80: Int (205 to 208) "123"
 81: String (210 to 211) "b"
 82: Variable (213 to 215) "$m"
-83: Record { pairs: [(NodeId(79), NodeId(80)), (NodeId(81), NodeId(82))] } (200 to 218)
+83: Record(RecordId(0)) (200 to 218)
 84: String (220 to 221) "a"
 85: Float (223 to 227) "12.3"
 86: String (229 to 230) "b"
 87: String (232 to 237) ""foo""
-88: Record { pairs: [(NodeId(84), NodeId(85)), (NodeId(86), NodeId(87))] } (218 to 239)
+88: Record(RecordId(1)) (218 to 239)
 89: Call(CallId(1)) (200 to 239)
 90: Let { variable_name: NodeId(70), ty: Some(NodeId(77)), initializer: NodeId(89), is_mutable: false } (171 to 239)
 91: Block(BlockId(2)) (0 to 240)

--- a/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
@@ -33,7 +33,7 @@ input_file: tests/infer_generics.nu
 25: Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(16)), block: NodeId(24), env: false, wrapped: false } (0 to 65)
 26: Name (67 to 68) "f"
 27: Int (69 to 70) "1"
-28: Call { parts: [NodeId(26), NodeId(27)] } (69 to 70)
+28: Call(CallId(0)) (69 to 70)
 29: Block(BlockId(1)) (0 to 71)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(29)

--- a/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
@@ -1,17 +1,18 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_generics.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 5) "f"
 1: Name (6 to 7) "T"
-2: Params([NodeId(1)]) (5 to 8)
+2: Params(ParamsId(0)) (5 to 8)
 3: Name (11 to 12) "x"
 4: Name (14 to 15) "T"
 5: Type { name: NodeId(4), args: None, optional: false } (14 to 15)
 6: Param { name: NodeId(3), ty: Some(NodeId(5)) } (11 to 15)
-7: Params([NodeId(6)]) (9 to 17)
+7: Params(ParamsId(1)) (9 to 17)
 8: Name (20 to 27) "nothing"
 9: Type { name: NodeId(8), args: None, optional: false } (20 to 27)
 10: Name (31 to 35) "list"
@@ -20,7 +21,7 @@ input_file: tests/infer_generics.nu
 13: TypeArgs([NodeId(12)]) (35 to 38)
 14: Type { name: NodeId(10), args: Some(NodeId(13)), optional: false } (31 to 35)
 15: InOutType(NodeId(9), NodeId(14)) (20 to 39)
-16: InOutTypes([NodeId(15)]) (20 to 39)
+16: InOutTypes(InOutTypesId(0)) (20 to 39)
 17: Variable (47 to 48) "z"
 18: Name (50 to 51) "T"
 19: Type { name: NodeId(18), args: None, optional: false } (50 to 51)
@@ -76,3 +77,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 25): node Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(16)), block: NodeId(24), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
@@ -18,7 +18,7 @@ input_file: tests/infer_generics.nu
 10: Name (31 to 35) "list"
 11: Name (36 to 37) "T"
 12: Type { name: NodeId(11), args: None, optional: false } (36 to 37)
-13: TypeArgs([NodeId(12)]) (35 to 38)
+13: TypeArgs(TypeArgsId(0)) (35 to 38)
 14: Type { name: NodeId(10), args: Some(NodeId(13)), optional: false } (31 to 35)
 15: InOutType(NodeId(9), NodeId(14)) (20 to 39)
 16: InOutTypes(InOutTypesId(0)) (20 to 39)

--- a/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
@@ -28,7 +28,7 @@ input_file: tests/infer_generics.nu
 20: Variable (54 to 56) "$x"
 21: Let { variable_name: NodeId(17), ty: Some(NodeId(19)), initializer: NodeId(20), is_mutable: false } (43 to 56)
 22: Variable (60 to 62) "$z"
-23: List([NodeId(22)]) (59 to 62)
+23: List(ListId(0)) (59 to 62)
 24: Block(BlockId(0)) (39 to 65)
 25: Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(16)), block: NodeId(24), env: false, wrapped: false } (0 to 65)
 26: Name (67 to 68) "f"

--- a/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
@@ -1,23 +1,24 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_plus.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 14) "mysterious"
 1: Name (15 to 16) "T"
-2: Params([NodeId(1)]) (14 to 17)
+2: Params(ParamsId(0)) (14 to 17)
 3: Name (20 to 21) "x"
 4: Name (23 to 26) "int"
 5: Type { name: NodeId(4), args: None, optional: false } (23 to 26)
 6: Param { name: NodeId(3), ty: Some(NodeId(5)) } (20 to 26)
-7: Params([NodeId(6)]) (18 to 28)
+7: Params(ParamsId(1)) (18 to 28)
 8: Name (31 to 38) "nothing"
 9: Type { name: NodeId(8), args: None, optional: false } (31 to 38)
 10: Name (42 to 43) "T"
 11: Type { name: NodeId(10), args: None, optional: false } (42 to 43)
 12: InOutType(NodeId(9), NodeId(11)) (31 to 44)
-13: InOutTypes([NodeId(12)]) (31 to 44)
+13: InOutTypes(InOutTypesId(0)) (31 to 44)
 14: Block(BlockId(0)) (44 to 46)
 15: Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(13)), block: NodeId(14), env: false, wrapped: false } (0 to 46)
 16: Variable (52 to 53) "m"
@@ -79,3 +80,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 15): node Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(13)), block: NodeId(14), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
@@ -24,7 +24,7 @@ input_file: tests/infer_plus.nu
 16: Variable (52 to 53) "m"
 17: Name (56 to 66) "mysterious"
 18: Int (67 to 68) "0"
-19: Call { parts: [NodeId(17), NodeId(18)] } (67 to 68)
+19: Call(CallId(0)) (67 to 68)
 20: Let { variable_name: NodeId(16), ty: None, initializer: NodeId(19), is_mutable: false } (48 to 68)
 21: Variable (70 to 72) "$m"
 22: Plus (73 to 74)

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -1,8 +1,8 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/invalid_record.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (2 to 3) "a"
@@ -10,8 +10,9 @@ snapshot_kind: text
 2: String (9 to 10) "b"
 3: Garbage (11 to 12)
 4: Garbage (13 to 13)
-5: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(4))] } (0 to 0)
+5: Record(RecordId(0)) (0 to 0)
 6: Block(BlockId(0)) (0 to 13)
 ==== COMPILER ERRORS ====
 Error (NodeId 3): expected: colon ':'
 Error (NodeId 4): incomplete expression
+

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/invalid_types.nu
 ---
@@ -14,7 +15,7 @@ input_file: tests/invalid_types.nu
 7: TypeArgs([NodeId(4), NodeId(6)]) (16 to 29)
 8: Type { name: NodeId(2), args: Some(NodeId(7)), optional: false } (12 to 16)
 9: Param { name: NodeId(1), ty: Some(NodeId(8)) } (9 to 16)
-10: Params([NodeId(9)]) (8 to 30)
+10: Params(ParamsId(0)) (8 to 30)
 11: Variable (33 to 35) "$x"
 12: Block(BlockId(0)) (31 to 37)
 13: Def { name: NodeId(0), type_params: None, params: NodeId(10), in_out_types: None, block: NodeId(12), env: false, wrapped: false } (0 to 37)
@@ -24,7 +25,7 @@ input_file: tests/invalid_types.nu
 17: TypeArgs([]) (54 to 56)
 18: Type { name: NodeId(16), args: Some(NodeId(17)), optional: false } (50 to 54)
 19: Param { name: NodeId(15), ty: Some(NodeId(18)) } (47 to 54)
-20: Params([NodeId(19)]) (46 to 57)
+20: Params(ParamsId(1)) (46 to 57)
 21: Variable (60 to 62) "$y"
 22: Block(BlockId(1)) (58 to 64)
 23: Def { name: NodeId(14), type_params: None, params: NodeId(20), in_out_types: None, block: NodeId(22), env: false, wrapped: false } (38 to 64)
@@ -70,3 +71,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 13): node Def { name: NodeId(0), type_params: None, params: NodeId(10), in_out_types: None, block: NodeId(12), env: false, wrapped: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
@@ -12,7 +12,7 @@ input_file: tests/invalid_types.nu
 4: Type { name: NodeId(3), args: None, optional: false } (17 to 20)
 5: Name (22 to 28) "string"
 6: Type { name: NodeId(5), args: None, optional: false } (22 to 28)
-7: TypeArgs([NodeId(4), NodeId(6)]) (16 to 29)
+7: TypeArgs(TypeArgsId(0)) (16 to 29)
 8: Type { name: NodeId(2), args: Some(NodeId(7)), optional: false } (12 to 16)
 9: Param { name: NodeId(1), ty: Some(NodeId(8)) } (9 to 16)
 10: Params(ParamsId(0)) (8 to 30)
@@ -22,7 +22,7 @@ input_file: tests/invalid_types.nu
 14: Name (42 to 45) "bar"
 15: Name (47 to 48) "y"
 16: Name (50 to 54) "list"
-17: TypeArgs([]) (54 to 56)
+17: TypeArgs(TypeArgsId(1)) (54 to 56)
 18: Type { name: NodeId(16), args: Some(NodeId(17)), optional: false } (50 to 54)
 19: Param { name: NodeId(15), ty: Some(NodeId(18)) } (47 to 54)
 20: Params(ParamsId(1)) (46 to 57)

--- a/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/let_mismatch.nu
 ---
@@ -38,7 +39,7 @@ input_file: tests/let_mismatch.nu
 31: Name (141 to 144) "int"
 32: Type { name: NodeId(31), args: None, optional: false } (141 to 144)
 33: Param { name: NodeId(30), ty: Some(NodeId(32)) } (138 to 144)
-34: Params([NodeId(33)]) (137 to 145)
+34: Params(ParamsId(0)) (137 to 145)
 35: RecordType { fields: NodeId(34), optional: false } (131 to 146)
 36: String (149 to 150) "a"
 37: String (152 to 157) ""foo""
@@ -101,3 +102,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 4): node Let { variable_name: NodeId(0), ty: Some(NodeId(2)), initializer: NodeId(3), is_mutable: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
@@ -25,9 +25,9 @@ input_file: tests/let_mismatch.nu
 17: Name (99 to 103) "list"
 18: Name (104 to 107) "int"
 19: Type { name: NodeId(18), args: None, optional: false } (104 to 107)
-20: TypeArgs([NodeId(19)]) (103 to 108)
+20: TypeArgs(TypeArgsId(0)) (103 to 108)
 21: Type { name: NodeId(17), args: Some(NodeId(20)), optional: false } (99 to 103)
-22: TypeArgs([NodeId(21)]) (98 to 109)
+22: TypeArgs(TypeArgsId(1)) (98 to 109)
 23: Type { name: NodeId(16), args: Some(NodeId(22)), optional: false } (94 to 98)
 24: String (116 to 119) "'a'"
 25: List(ListId(0)) (114 to 120)

--- a/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
@@ -30,8 +30,8 @@ input_file: tests/let_mismatch.nu
 22: TypeArgs([NodeId(21)]) (98 to 109)
 23: Type { name: NodeId(16), args: Some(NodeId(22)), optional: false } (94 to 98)
 24: String (116 to 119) "'a'"
-25: List([NodeId(24)]) (114 to 120)
-26: List([NodeId(25)]) (112 to 122)
+25: List(ListId(0)) (114 to 120)
+26: List(ListId(1)) (112 to 122)
 27: Let { variable_name: NodeId(15), ty: Some(NodeId(23)), initializer: NodeId(26), is_mutable: false } (87 to 122)
 28: Variable (128 to 129) "v"
 29: Name (131 to 137) "record"

--- a/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
@@ -43,7 +43,7 @@ input_file: tests/let_mismatch.nu
 35: RecordType { fields: NodeId(34), optional: false } (131 to 146)
 36: String (149 to 150) "a"
 37: String (152 to 157) ""foo""
-38: Record { pairs: [(NodeId(36), NodeId(37))] } (148 to 158)
+38: Record(RecordId(0)) (148 to 158)
 39: Let { variable_name: NodeId(28), ty: Some(NodeId(35)), initializer: NodeId(38), is_mutable: false } (124 to 158)
 40: Block(BlockId(0)) (0 to 159)
 ==== SCOPE ====

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -1,30 +1,30 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/list.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (1 to 2) "1"
 1: Int (4 to 5) "2"
 2: Int (7 to 8) "3"
-3: List([NodeId(0), NodeId(1), NodeId(2)]) (0 to 8)
+3: List(ListId(0)) (0 to 8)
 4: Int (11 to 12) "0"
 5: Int (13 to 14) "1"
 6: Int (15 to 16) "2"
-7: List([NodeId(4), NodeId(5), NodeId(6)]) (10 to 16)
+7: List(ListId(1)) (10 to 16)
 8: String (19 to 22) ""0""
 9: String (23 to 26) ""1""
 10: String (27 to 30) ""2""
-11: List([NodeId(8), NodeId(9), NodeId(10)]) (18 to 30)
+11: List(ListId(2)) (18 to 30)
 12: Int (33 to 34) "0"
 13: Int (35 to 36) "1"
 14: Float (37 to 40) "2.2"
-15: List([NodeId(12), NodeId(13), NodeId(14)]) (32 to 40)
+15: List(ListId(3)) (32 to 40)
 16: Int (43 to 44) "0"
 17: Int (45 to 46) "1"
 18: String (47 to 50) ""2""
-19: List([NodeId(16), NodeId(17), NodeId(18)]) (42 to 50)
+19: List(ListId(4)) (42 to 50)
 20: Block(BlockId(0)) (0 to 52)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(20) (empty)
@@ -54,4 +54,5 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 3): node List([NodeId(0), NodeId(1), NodeId(2)]) not suported yet
+Error (NodeId 3): node List(ListId(0)) not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -1,8 +1,8 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/literals.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: True (1 to 5)
@@ -10,7 +10,7 @@ snapshot_kind: text
 2: Int (11 to 12) "1"
 3: String (13 to 16) "abc"
 4: String (17 to 22) ""foo""
-5: List([NodeId(0), NodeId(1), NodeId(2), NodeId(3), NodeId(4)]) (0 to 22)
+5: List(ListId(0)) (0 to 22)
 6: Block(BlockId(0)) (0 to 24)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6) (empty)
@@ -26,4 +26,5 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 5): node List([NodeId(0), NodeId(1), NodeId(2), NodeId(3), NodeId(4)]) not suported yet
+Error (NodeId 5): node List(ListId(0)) not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@match.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@match.nu.snap
@@ -1,8 +1,8 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/match.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -26,8 +26,9 @@ snapshot_kind: text
 18: Null (92 to 96)
 19: String (100 to 101) "_"
 20: Garbage (106 to 107)
-21: Match { target: NodeId(4), match_arms: [(NodeId(5), NodeId(6)), (NodeId(7), NodeId(16)), (NodeId(17), NodeId(18)), (NodeId(19), NodeId(20))] } (21 to 110)
+21: Match(MatchId(0)) (21 to 110)
 22: Let { variable_name: NodeId(3), ty: None, initializer: NodeId(21), is_mutable: false } (11 to 110)
 23: Block(BlockId(1)) (0 to 111)
 ==== COMPILER ERRORS ====
 Error (NodeId 20): use null instead of ()
+

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -1,15 +1,15 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (1 to 2) "a"
 1: Int (4 to 5) "1"
 2: String (7 to 8) "b"
 3: Int (10 to 11) "2"
-4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 12)
+4: Record(RecordId(0)) (0 to 12)
 5: Block(BlockId(0)) (0 to 13)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
@@ -24,4 +24,5 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 4): node Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } not suported yet
+Error (NodeId 4): node Record(RecordId(0)) not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
@@ -1,15 +1,15 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record2.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (1 to 4) ""a""
 1: Int (6 to 7) "1"
 2: String (9 to 12) ""b""
 3: Int (14 to 15) "2"
-4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 16)
+4: Record(RecordId(0)) (0 to 16)
 5: Block(BlockId(0)) (0 to 17)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
@@ -24,4 +24,5 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 4): node Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } not suported yet
+Error (NodeId 4): node Record(RecordId(0)) not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -1,15 +1,15 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record3.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (2 to 3) "a"
 1: Int (5 to 6) "1"
 2: String (9 to 10) "b"
 3: Int (12 to 13) "2"
-4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 16)
+4: Record(RecordId(0)) (0 to 16)
 5: Block(BlockId(0)) (0 to 17)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
@@ -24,4 +24,5 @@ snapshot_kind: text
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 4): node Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } not suported yet
+Error (NodeId 4): node Record(RecordId(0)) not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -1,14 +1,14 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/reparse.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
 1: Name (10 to 11) "a"
 2: Param { name: NodeId(1), ty: None } (10 to 11)
-3: Params([NodeId(2)]) (9 to 12)
+3: Params(ParamsId(0)) (9 to 12)
 4: Variable (13 to 15) "$a"
 5: Block(BlockId(0)) (13 to 16)
 6: Closure { params: Some(NodeId(3)), block: NodeId(5) } (8 to 17)
@@ -44,3 +44,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 7): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(6), is_mutable: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -16,7 +16,7 @@ input_file: tests/reparse.nu
 8: Variable (22 to 23) "y"
 9: String (28 to 29) "a"
 10: String (31 to 32) "b"
-11: Record { pairs: [(NodeId(9), NodeId(10))] } (26 to 34)
+11: Record(RecordId(0)) (26 to 34)
 12: Let { variable_name: NodeId(8), ty: None, initializer: NodeId(11), is_mutable: false } (18 to 34)
 13: Block(BlockId(1)) (0 to 34)
 ==== SCOPE ====

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -1,18 +1,19 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/table.nu
 ---
 ==== COMPILER ====
 0: String (7 to 10) ""a""
 1: String (12 to 15) ""b""
-2: List([NodeId(0), NodeId(1)]) (6 to 15)
+2: List(ListId(0)) (6 to 15)
 3: Int (24 to 25) "1"
 4: Int (27 to 28) "2"
-5: List([NodeId(3), NodeId(4)]) (23 to 28)
+5: List(ListId(1)) (23 to 28)
 6: Int (35 to 36) "3"
 7: Int (38 to 39) "4"
-8: List([NodeId(6), NodeId(7)]) (34 to 39)
+8: List(ListId(2)) (34 to 39)
 9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 41)
 10: Block(BlockId(0)) (0 to 42)
 ==== SCOPE ====
@@ -36,3 +37,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 9): node Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -14,7 +14,7 @@ input_file: tests/table.nu
 6: Int (35 to 36) "3"
 7: Int (38 to 39) "4"
 8: List(ListId(2)) (34 to 39)
-9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 41)
+9: Table(TableId(0)) (0 to 41)
 10: Block(BlockId(0)) (0 to 42)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10) (empty)
@@ -31,10 +31,10 @@ input_file: tests/table.nu
 9: error
 10: error
 ==== TYPE ERRORS ====
-Error (NodeId 9): Expected an expression to typecheck, got 'Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] }'
+Error (NodeId 9): Expected an expression to typecheck, got 'Table(TableId(0))'
 ==== IR ====
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 9): node Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } not suported yet
+Error (NodeId 9): node Table(TableId(0)) not suported yet
 

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -1,18 +1,19 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/table2.nu
 ---
 ==== COMPILER ====
 0: String (7 to 8) "a"
 1: String (10 to 11) "b"
-2: List([NodeId(0), NodeId(1)]) (6 to 11)
+2: List(ListId(0)) (6 to 11)
 3: Int (20 to 21) "1"
 4: Int (23 to 24) "2"
-5: List([NodeId(3), NodeId(4)]) (19 to 24)
+5: List(ListId(1)) (19 to 24)
 6: Int (31 to 32) "3"
 7: Int (34 to 35) "4"
-8: List([NodeId(6), NodeId(7)]) (30 to 35)
+8: List(ListId(2)) (30 to 35)
 9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 37)
 10: Block(BlockId(0)) (0 to 38)
 ==== SCOPE ====
@@ -36,3 +37,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 9): node Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -14,7 +14,7 @@ input_file: tests/table2.nu
 6: Int (31 to 32) "3"
 7: Int (34 to 35) "4"
 8: List(ListId(2)) (30 to 35)
-9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 37)
+9: Table(TableId(0)) (0 to 37)
 10: Block(BlockId(0)) (0 to 38)
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10) (empty)
@@ -31,10 +31,10 @@ input_file: tests/table2.nu
 9: error
 10: error
 ==== TYPE ERRORS ====
-Error (NodeId 9): Expected an expression to typecheck, got 'Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] }'
+Error (NodeId 9): Expected an expression to typecheck, got 'Table(TableId(0))'
 ==== IR ====
 register_count: 0
 file_count: 0
 ==== IR ERRORS ====
-Error (NodeId 9): node Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } not suported yet
+Error (NodeId 9): node Table(TableId(0)) not suported yet
 

--- a/src/snapshots/new_nu_parser__test__node_output@try.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@try.nu.snap
@@ -1,5 +1,6 @@
 ---
 source: src/test.rs
+assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/try.nu
 ---
@@ -17,7 +18,7 @@ input_file: tests/try.nu
 10: Block(BlockId(1)) (23 to 37)
 11: Name (49 to 54) "print"
 12: String (55 to 59) ""aa""
-13: Call { parts: [NodeId(11), NodeId(12)] } (55 to 59)
+13: Call(CallId(0)) (55 to 59)
 14: Block(BlockId(2)) (43 to 61)
 15: Try { try_block: NodeId(10), catch_block: Some(NodeId(14)), finally_block: None } (19 to 61)
 16: Int (73 to 74) "1"
@@ -27,7 +28,7 @@ input_file: tests/try.nu
 20: Block(BlockId(3)) (67 to 81)
 21: Name (95 to 100) "print"
 22: String (101 to 105) ""bb""
-23: Call { parts: [NodeId(21), NodeId(22)] } (101 to 105)
+23: Call(CallId(1)) (101 to 105)
 24: Block(BlockId(4)) (89 to 107)
 25: Try { try_block: NodeId(20), catch_block: None, finally_block: Some(NodeId(24)) } (63 to 107)
 26: Int (119 to 120) "1"
@@ -39,7 +40,7 @@ input_file: tests/try.nu
 32: Block(BlockId(6)) (133 to 144)
 33: Name (158 to 163) "print"
 34: String (164 to 168) ""bb""
-35: Call { parts: [NodeId(33), NodeId(34)] } (164 to 168)
+35: Call(CallId(2)) (164 to 168)
 36: Block(BlockId(7)) (152 to 170)
 37: Try { try_block: NodeId(30), catch_block: Some(NodeId(32)), finally_block: Some(NodeId(36)) } (109 to 170)
 38: Block(BlockId(8)) (0 to 172)
@@ -95,3 +96,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 5): node Try { try_block: NodeId(4), catch_block: None, finally_block: None } not suported yet
+

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -270,8 +270,8 @@ impl<'a> Typechecker<'a> {
                     self.set_node_type_id(node_id, ANY_TYPE);
                 }
             }
-            AstNode::TypeArgs(ref args) => {
-                for arg in args {
+            AstNode::TypeArgs(_) => {
+                for arg in &self.compiler.get_type_args(node_id).args {
                     self.typecheck_type(*arg);
                 }
                 // Type argument lists are not supposed to be evaluated
@@ -500,12 +500,11 @@ impl<'a> Typechecker<'a> {
                 let parts = self.compiler.get_call(node_id).parts.clone();
                 self.typecheck_call(&parts, node_id)
             }
-            AstNode::Match {
-                ref target,
-                ref match_arms,
-            } => {
+            AstNode::Match(_) => {
+                let match_node = self.compiler.get_match(node_id);
                 // Check all the output types of match
-                let output_types = self.typecheck_match(target, match_arms, expected);
+                let output_types =
+                    self.typecheck_match(&match_node.target, &match_node.match_arms, expected);
                 if output_types.is_empty() {
                     NOTHING_TYPE
                 } else {
@@ -557,7 +556,7 @@ impl<'a> Typechecker<'a> {
                 | AstNode::BinaryOp { .. }
                 | AstNode::If { .. }
                 | AstNode::Call(_)
-                | AstNode::Match { .. }
+                | AstNode::Match(_)
         )
     }
 
@@ -875,7 +874,11 @@ impl<'a> Typechecker<'a> {
             let num_args = parts.len() - num_name_parts;
             if params.nodes.len() != num_args {
                 self.error(
-                    format!("Expected {} argument(s), got {}", params.nodes.len(), num_args),
+                    format!(
+                        "Expected {} argument(s), got {}",
+                        params.nodes.len(),
+                        num_args
+                    ),
                     node_id,
                 );
             }
@@ -1019,7 +1022,8 @@ impl<'a> Typechecker<'a> {
                 if let Some(args_id) = args_id {
                     self.typecheck_node(args_id);
 
-                    if let AstNode::TypeArgs(args) = self.compiler.get_node(args_id) {
+                    if let AstNode::TypeArgs(_) = self.compiler.get_node(args_id) {
+                        let args = &self.compiler.get_type_args(args_id).args;
                         if args.len() > 1 {
                             let types =
                                 String::from_utf8_lossy(self.compiler.get_span_contents(args_id));

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -392,9 +392,10 @@ impl<'a> Typechecker<'a> {
             AstNode::Float => FLOAT_TYPE,
             AstNode::True | AstNode::False => BOOL_TYPE,
             AstNode::String => STRING_TYPE,
-            AstNode::List(ref items) => {
+            AstNode::List(_) => {
+                let items = self.compiler.get_list(node_id);
                 // TODO infer a union type instead
-                if let Some(first_id) = items.first() {
+                if let Some(first_id) = items.items.first() {
                     let expected_elem = self.extract_elem_type(expected);
                     self.typecheck_expr(*first_id, expected_elem.unwrap_or(TOP_TYPE));
                     let first_type = self.type_of(*first_id);
@@ -402,7 +403,7 @@ impl<'a> Typechecker<'a> {
                     let mut all_numbers = self.is_type_compatible(first_type, Type::Number);
                     let mut all_same = true;
 
-                    for item_id in items.iter().skip(1) {
+                    for item_id in items.items.iter().skip(1) {
                         self.typecheck_expr(*item_id, TOP_TYPE);
                         let item_type = self.type_of(*item_id);
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -781,10 +781,9 @@ impl<'a> Typechecker<'a> {
     ) {
         let in_out_types = in_out_types
             .map(|ty| {
-                let AstNode::InOutTypes(types) = self.compiler.get_node(ty) else {
-                    panic!("internal error: return type is not a return type");
-                };
-                types
+                self.compiler
+                    .get_in_out_types(ty)
+                    .nodes
                     .iter()
                     .map(|ty| {
                         let AstNode::InOutType(in_ty, out_ty) = self.compiler.get_node(*ty) else {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -247,8 +247,9 @@ impl<'a> Typechecker<'a> {
 
     fn typecheck_node(&mut self, node_id: NodeId) {
         match self.compiler.ast_nodes[node_id.0] {
-            AstNode::Params(ref params) => {
-                for param in params {
+            AstNode::Params(_) => {
+                let params = self.compiler.get_params(node_id);
+                for param in &params.nodes {
                     self.typecheck_node(*param);
                 }
                 // Params are not supposed to be evaluated
@@ -853,16 +854,11 @@ impl<'a> Typechecker<'a> {
             else {
                 panic!("Internal error: Expected def")
             };
-            let AstNode::Params(params) = self.compiler.get_node(*params) else {
-                panic!("Internal error: Expected params")
-            };
+            let params = self.compiler.get_params(*params);
 
             let type_substs = if let Some(type_params) = type_params {
-                let AstNode::Params(type_params) = self.compiler.get_node(*type_params) else {
-                    panic!("Internal error: expected type params");
-                };
                 let mut type_substs = HashMap::new();
-                for type_param in type_params.iter() {
+                for type_param in &self.compiler.get_params(*type_params).nodes {
                     let type_decl_id = self.compiler.type_resolution[type_param];
                     let var = self.new_typevar(BOTTOM_TYPE, TOP_TYPE);
                     type_substs.insert(type_decl_id, var);
@@ -873,13 +869,13 @@ impl<'a> Typechecker<'a> {
             };
 
             let num_args = parts.len() - num_name_parts;
-            if params.len() != num_args {
+            if params.nodes.len() != num_args {
                 self.error(
-                    format!("Expected {} argument(s), got {}", params.len(), num_args),
+                    format!("Expected {} argument(s), got {}", params.nodes.len(), num_args),
                     node_id,
                 );
             }
-            for (param, arg) in params.iter().zip(&parts[num_name_parts..]) {
+            for (param, arg) in params.nodes.iter().zip(&parts[num_name_parts..]) {
                 let expected = self.type_id_of(*param);
                 let expected = self.subst(expected, &type_substs);
                 if matches!(self.compiler.ast_nodes[arg.0], AstNode::Name) {
@@ -894,9 +890,9 @@ impl<'a> Typechecker<'a> {
                     self.typecheck_expr(*arg, expected);
                 }
             }
-            if num_args > params.len() {
+            if num_args > params.nodes.len() {
                 // Typecheck extra arguments too
-                for arg in &parts[num_name_parts + params.len()..] {
+                for arg in &parts[num_name_parts + params.nodes.len()..] {
                     if matches!(self.compiler.ast_nodes[arg.0], AstNode::Name) {
                         self.set_node_type_id(*arg, STRING_TYPE);
                     } else {
@@ -963,10 +959,9 @@ impl<'a> Typechecker<'a> {
                 fields,
                 optional: _, // TODO handle optional record types
             } => {
-                let AstNode::Params(field_nodes) = self.compiler.get_node(fields) else {
-                    panic!("internal error: record fields aren't Params");
-                };
+                let field_nodes = self.compiler.get_params(fields);
                 let mut fields = field_nodes
+                    .nodes
                     .iter()
                     .map(|field| {
                         let AstNode::Param { name, ty } = self.compiler.get_node(*field) else {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -550,7 +550,7 @@ impl<'a> Typechecker<'a> {
                 | AstNode::Variable
                 | AstNode::List(_)
                 | AstNode::Record { .. }
-                | AstNode::Table { .. }
+                | AstNode::Table(_)
                 | AstNode::Pipeline(_)
                 | AstNode::Closure { .. }
                 | AstNode::BinaryOp { .. }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -494,7 +494,10 @@ impl<'a> Typechecker<'a> {
                     NONE_TYPE
                 }
             }
-            AstNode::Call { ref parts } => self.typecheck_call(parts, node_id),
+            AstNode::Call(_) => {
+                let parts = self.compiler.get_call(node_id).parts.clone();
+                self.typecheck_call(&parts, node_id)
+            }
             AstNode::Match {
                 ref target,
                 ref match_arms,
@@ -551,7 +554,7 @@ impl<'a> Typechecker<'a> {
                 | AstNode::Closure { .. }
                 | AstNode::BinaryOp { .. }
                 | AstNode::If { .. }
-                | AstNode::Call { .. }
+                | AstNode::Call(_)
                 | AstNode::Match { .. }
         )
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -427,7 +427,8 @@ impl<'a> Typechecker<'a> {
                     LIST_ANY_TYPE
                 }
             }
-            AstNode::Record { ref pairs } => {
+            AstNode::Record(_) => {
+                let pairs = &self.compiler.get_record(node_id).pairs;
                 // TODO take expected type into account
                 let mut field_types = pairs
                     .iter()
@@ -549,7 +550,7 @@ impl<'a> Typechecker<'a> {
                 | AstNode::String
                 | AstNode::Variable
                 | AstNode::List(_)
-                | AstNode::Record { .. }
+                | AstNode::Record(_)
                 | AstNode::Table(_)
                 | AstNode::Pipeline(_)
                 | AstNode::Closure { .. }


### PR DESCRIPTION
I noted there is a to do comment about AstNode:
```
// TODO: All nodes with Vec<...> should be moved to their own ID (like BlockId) to allow Copy trait
```
This pr is going to implement it.

To be honest I'm not really sure if it's intended, because it introduces some indirection.  But I think it addresses comment from https://github.com/nushell/new-nu-parser/pull/68#issuecomment-4366456604 to introduce some helper functions to Compiler, so we can use it in a better way.