### PR TITLE
Fix type inferencing in partial if blocks

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,4 +4,4 @@
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
 # When updating, it might be necessary to run `nix flake update`.
-channel = "1.90.0"
+channel = "1.96.0"

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -491,8 +491,14 @@ impl<'a> Typechecker<'a> {
                     types.insert(then_type_id);
                     types.insert(else_type_id);
                     self.create_oneof(types)
+                } else if then_type_id != NONE_TYPE {
+                    // If the then-block is not a statement, then the
+                    // resulting type is OneOf(Nothing, then_type)
+                    let mut types = HashSet::new();
+                    types.insert(then_type_id);
+                    types.insert(NONE_TYPE);
+                    self.create_oneof(types)
                 } else {
-                    // If there's no else block, the if expression is a statement
                     NONE_TYPE
                 }
             }


### PR DESCRIPTION
If the if-block is not followed by an else block, the typechecker incorrectly assumes that the type of the resulting node would be NONE_TYPE. That's not necessary, since current semantics set the type to be a oneof(nothing, _) type

Fixes #72 