### PR TITLE
Compiler: print out sub_nodes if the a ast node contains Vec<AstNode>.

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -155,19 +155,67 @@ impl Compiler {
         // TODO: This should say PARSER, not COMPILER
         let mut result = "==== COMPILER ====\n".to_string();
 
+        fn display_items<T>(items: &[T], display_item: impl Fn(&T) -> String) -> String {
+            if items.len() <= 7 {
+                items
+                    .iter()
+                    .map(display_item)
+                    .collect::<Vec<String>>()
+                    .join(",")
+            } else {
+                let mut visible_items = Vec::with_capacity(5);
+                visible_items.extend(items.iter().take(2).map(&display_item));
+                visible_items.push("...".to_string());
+                visible_items.extend(items[items.len() - 2..].iter().map(display_item));
+                visible_items.join(",")
+            }
+        }
+
+        fn display_nodes(nodes: &[NodeId]) -> String {
+            display_items(nodes, |node_id| node_id.to_string())
+        }
+
+        fn display_node_pairs(pairs: &[(NodeId, NodeId)]) -> String {
+            display_items(pairs, |(lhs, rhs)| format!("{lhs}: {rhs}"))
+        }
+
         for (idx, ast_node) in self.ast_nodes.iter().enumerate() {
             let sub_nodes_str = match ast_node {
-                AstNode::TypeArgs(type_args_id) => Some(&self.type_args[type_args_id.0].args),
-                AstNode::Params(params_id) => Some(&self.params[params_id.0].nodes),
+                AstNode::Block(block_id) => Some(display_nodes(&self.blocks[block_id.0].nodes)),
+                AstNode::TypeArgs(type_args_id) => {
+                    Some(display_nodes(&self.type_args[type_args_id.0].args))
+                }
+                AstNode::Params(params_id) => Some(display_nodes(&self.params[params_id.0].nodes)),
+                AstNode::InOutTypes(in_out_types_id) => {
+                    Some(display_nodes(&self.in_out_types[in_out_types_id.0].nodes))
+                }
+                AstNode::Call(call_id) => Some(display_nodes(&self.calls[call_id.0].parts)),
+                AstNode::List(list_id) => Some(display_nodes(&self.lists[list_id.0].items)),
+                AstNode::Table(table_id) => {
+                    let table = &self.tables[table_id.0];
+                    Some(format!(
+                        "header: {}, rows: {}",
+                        table.header,
+                        display_nodes(&table.rows)
+                    ))
+                }
+                AstNode::Record(record_id) => {
+                    let record = &self.records[record_id.0];
+                    Some(format!("pairs: {}", display_node_pairs(&record.pairs)))
+                }
+                AstNode::Match(match_id) => {
+                    let match_node = &self.matches[match_id.0];
+                    Some(format!(
+                        "target: {}, arms: {}",
+                        match_node.target,
+                        display_node_pairs(&match_node.match_arms)
+                    ))
+                }
+                AstNode::Pipeline(pipeline_id) => {
+                    Some(display_nodes(&self.pipelines[pipeline_id.0].nodes))
+                }
                 _ => None,
-            }
-            .map(|nodes| {
-                nodes
-                    .iter()
-                    .map(|node_id| node_id.to_string())
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            });
+            };
 
             match sub_nodes_str {
                 Some(sub_nodes) => result.push_str(&format!(

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -156,10 +156,29 @@ impl Compiler {
         let mut result = "==== COMPILER ====\n".to_string();
 
         for (idx, ast_node) in self.ast_nodes.iter().enumerate() {
-            result.push_str(&format!(
-                "{}: {:?} ({} to {})",
-                idx, ast_node, self.spans[idx].start, self.spans[idx].end
-            ));
+            let sub_nodes_str = match ast_node {
+                AstNode::TypeArgs(type_args_id) => Some(&self.type_args[type_args_id.0].args),
+                AstNode::Params(params_id) => Some(&self.params[params_id.0].nodes),
+                _ => None,
+            }
+            .map(|nodes| {
+                nodes
+                    .iter()
+                    .map(|node_id| node_id.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            });
+
+            match sub_nodes_str {
+                Some(sub_nodes) => result.push_str(&format!(
+                    "{}: {:?} ({} to {}) - sub_nodes: {}",
+                    idx, ast_node, self.spans[idx].start, self.spans[idx].end, sub_nodes
+                )),
+                None => result.push_str(&format!(
+                    "{}: {:?} ({} to {})",
+                    idx, ast_node, self.spans[idx].start, self.spans[idx].end
+                )),
+            }
 
             if matches!(
                 ast_node,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -218,6 +218,10 @@ impl Compiler {
             };
 
             match sub_nodes_str {
+                Some(sub_nodes) if sub_nodes.is_empty() => result.push_str(&format!(
+                    "{}: {:?} ({} to {}) - sub_nodes is empty",
+                    idx, ast_node, self.spans[idx].start, self.spans[idx].end
+                )),
                 Some(sub_nodes) => result.push_str(&format!(
                     "{}: {:?} ({} to {}) - sub_nodes: {}",
                     idx, ast_node, self.spans[idx].start, self.spans[idx].end, sub_nodes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::compiler::{Compiler, RollbackPoint, Span};
 use crate::errors::{Severity, SourceError};
 use crate::lexer::{Token, Tokens};
@@ -9,8 +11,16 @@ pub struct Parser {
     tokens: Tokens,
 }
 
+/// This is bottom-level ast node ids, every AstNode will be created
+/// and save in the compiler, indexed by compilder.ast_nodes
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub usize);
+
+impl Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockId(pub usize);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ pub struct Parser {
 }
 
 /// This is bottom-level ast node ids, every AstNode will be created
-/// and save in the compiler, indexed by compilder.ast_nodes
+/// and save into compilder.ast_nodes
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub usize);
 

--- a/src/snapshots/new_nu_parser__test__node_output@alias.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@alias.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/alias.nu
 ---
@@ -10,8 +9,8 @@ input_file: tests/alias.nu
 2: Alias { new_name: NodeId(0), old_name: NodeId(1) } (0 to 25)
 3: Name (27 to 32) "fancy"
 4: Name (33 to 38) "alias"
-5: Call(CallId(0)) (33 to 38)
-6: Block(BlockId(0)) (0 to 39)
+5: Call(CallId(0)) (33 to 38) - sub_nodes: 3,4
+6: Block(BlockId(0)) (0 to 39) - sub_nodes: 2,5
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6)
       decls: [ fancy alias: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_exact.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/binary_ops_exact.nu
 ---
@@ -10,10 +9,10 @@ input_file: tests/binary_ops_exact.nu
 2: Int (5 to 6) "1"
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 6)
 4: True (8 to 12)
-5: List(ListId(0)) (7 to 12)
+5: List(ListId(0)) (7 to 12) - sub_nodes: 4
 6: Append (14 to 16)
 7: False (18 to 23)
-8: List(ListId(1)) (17 to 23)
+8: List(ListId(1)) (17 to 23) - sub_nodes: 7
 9: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(8) } (7 to 23)
 10: Int (25 to 26) "1"
 11: Plus (27 to 28)
@@ -35,9 +34,9 @@ input_file: tests/binary_ops_exact.nu
 27: In (73 to 75)
 28: Int (77 to 78) "1"
 29: Int (80 to 81) "2"
-30: List(ListId(2)) (76 to 81)
+30: List(ListId(2)) (76 to 81) - sub_nodes: 28,29
 31: BinaryOp { lhs: NodeId(26), op: NodeId(27), rhs: NodeId(30) } (71 to 81)
-32: Block(BlockId(0)) (0 to 83)
+32: Block(BlockId(0)) (0 to 83) - sub_nodes: 3,9,13,17,21,25,31
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(32) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_mismatch.nu.snap
@@ -20,7 +20,7 @@ input_file: tests/binary_ops_mismatch.nu
 13: NotRegexMatch (39 to 41)
 14: String (42 to 48) ""true""
 15: BinaryOp { lhs: NodeId(12), op: NodeId(13), rhs: NodeId(14) } (34 to 48)
-16: Block(BlockId(0)) (0 to 49)
+16: Block(BlockId(0)) (0 to 49) - sub_nodes: 3,7,11,15
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(16) (empty)
 ==== TYPES ====
@@ -53,3 +53,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 0): node String not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_spaces.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_spaces.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/binary_ops_spaces.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (0 to 1) "1"
@@ -21,9 +20,10 @@ snapshot_kind: text
 13: Plus (17 to 18)
 14: Int (18 to 19) "2"
 15: BinaryOp { lhs: NodeId(12), op: NodeId(13), rhs: NodeId(14) } (16 to 19)
-16: Block(BlockId(0)) (0 to 20)
+16: Block(BlockId(0)) (0 to 20) - sub_nodes: 3,7,11,15
 ==== COMPILER ERRORS ====
 Error (NodeId 5): missing space before operator
 Error (NodeId 9): missing space after operator
 Error (NodeId 13): missing space before operator
 Error (NodeId 13): missing space after operator
+

--- a/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@binary_ops_subtypes.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/binary_ops_subtypes.nu
 ---
@@ -18,43 +17,43 @@ input_file: tests/binary_ops_subtypes.nu
 10: Float (24 to 27) "1.0"
 11: BinaryOp { lhs: NodeId(8), op: NodeId(9), rhs: NodeId(10) } (20 to 27)
 12: Int (29 to 30) "1"
-13: List(ListId(0)) (28 to 30)
+13: List(ListId(0)) (28 to 30) - sub_nodes: 12
 14: Append (32 to 34)
 15: Float (36 to 39) "1.0"
-16: List(ListId(1)) (35 to 39)
+16: List(ListId(1)) (35 to 39) - sub_nodes: 15
 17: BinaryOp { lhs: NodeId(13), op: NodeId(14), rhs: NodeId(16) } (28 to 39)
 18: Float (42 to 45) "1.0"
 19: Int (46 to 47) "1"
-20: List(ListId(2)) (41 to 47)
+20: List(ListId(2)) (41 to 47) - sub_nodes: 18,19
 21: Append (49 to 51)
 22: String (53 to 56) ""a""
-23: List(ListId(3)) (52 to 56)
+23: List(ListId(3)) (52 to 56) - sub_nodes: 22
 24: BinaryOp { lhs: NodeId(20), op: NodeId(21), rhs: NodeId(23) } (41 to 56)
 25: Int (60 to 61) "1"
-26: List(ListId(4)) (59 to 61)
+26: List(ListId(4)) (59 to 61) - sub_nodes: 25
 27: Int (64 to 65) "2"
-28: List(ListId(5)) (63 to 65)
-29: List(ListId(6)) (58 to 66)
+28: List(ListId(5)) (63 to 65) - sub_nodes: 27
+29: List(ListId(6)) (58 to 66) - sub_nodes: 26,28
 30: Append (68 to 70)
 31: Int (73 to 74) "3"
-32: List(ListId(7)) (72 to 74)
-33: List(ListId(8)) (71 to 75)
+32: List(ListId(7)) (72 to 74) - sub_nodes: 31
+33: List(ListId(8)) (71 to 75) - sub_nodes: 32
 34: BinaryOp { lhs: NodeId(29), op: NodeId(30), rhs: NodeId(33) } (58 to 75)
 35: Int (79 to 80) "1"
-36: List(ListId(9)) (78 to 80)
+36: List(ListId(9)) (78 to 80) - sub_nodes: 35
 37: Int (83 to 84) "2"
-38: List(ListId(10)) (82 to 84)
-39: List(ListId(11)) (77 to 85)
+38: List(ListId(10)) (82 to 84) - sub_nodes: 37
+39: List(ListId(11)) (77 to 85) - sub_nodes: 36,38
 40: Append (87 to 89)
 41: Float (92 to 95) "3.0"
-42: List(ListId(12)) (91 to 95)
-43: List(ListId(13)) (90 to 96)
+42: List(ListId(12)) (91 to 95) - sub_nodes: 41
+43: List(ListId(13)) (90 to 96) - sub_nodes: 42
 44: BinaryOp { lhs: NodeId(39), op: NodeId(40), rhs: NodeId(43) } (77 to 96)
 45: Int (98 to 99) "1"
 46: In (100 to 102)
 47: Float (104 to 107) "1.0"
 48: Int (109 to 110) "1"
-49: List(ListId(14)) (103 to 110)
+49: List(ListId(14)) (103 to 110) - sub_nodes: 47,48
 50: BinaryOp { lhs: NodeId(45), op: NodeId(46), rhs: NodeId(49) } (98 to 110)
 51: Float (112 to 115) "2.3"
 52: Modulo (116 to 119)
@@ -64,8 +63,8 @@ input_file: tests/binary_ops_subtypes.nu
 56: Int (127 to 128) "2"
 57: String (130 to 131) "c"
 58: Int (133 to 134) "3"
-59: Record(RecordId(0)) (123 to 135)
-60: List(ListId(15)) (122 to 135)
+59: Record(RecordId(0)) (123 to 135) - sub_nodes: pairs: 55: 56,57: 58
+60: List(ListId(15)) (122 to 135) - sub_nodes: 59
 61: Append (137 to 139)
 62: String (142 to 143) "a"
 63: Int (145 to 146) "3"
@@ -73,10 +72,10 @@ input_file: tests/binary_ops_subtypes.nu
 65: Float (151 to 154) "1.5"
 66: String (156 to 157) "c"
 67: String (159 to 164) ""foo""
-68: Record(RecordId(1)) (141 to 165)
-69: List(ListId(16)) (140 to 165)
+68: Record(RecordId(1)) (141 to 165) - sub_nodes: pairs: 62: 63,64: 65,66: 67
+69: List(ListId(16)) (140 to 165) - sub_nodes: 68
 70: BinaryOp { lhs: NodeId(60), op: NodeId(61), rhs: NodeId(69) } (122 to 165)
-71: Block(BlockId(0)) (0 to 167)
+71: Block(BlockId(0)) (0 to 167) - sub_nodes: 3,7,...,54,70
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(71) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/calls.nu
 ---
@@ -12,7 +11,7 @@ input_file: tests/calls.nu
 4: Plus (18 to 19)
 5: Int (20 to 21) "2"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 21)
-7: Call(CallId(0)) (5 to 22)
+7: Call(CallId(0)) (5 to 22) - sub_nodes: 0,1,2,6
 8: Name (28 to 36) "existing"
 9: Name (38 to 39) "a"
 10: Name (41 to 47) "string"
@@ -26,12 +25,12 @@ input_file: tests/calls.nu
 18: Name (63 to 66) "int"
 19: Type { name: NodeId(18), args: None, optional: false } (63 to 66)
 20: Param { name: NodeId(17), ty: Some(NodeId(19)) } (60 to 66)
-21: Params(ParamsId(0)) (37 to 67)
+21: Params(ParamsId(0)) (37 to 67) - sub_nodes: 12,16,20
 22: Variable (72 to 74) "$a"
 23: Variable (76 to 78) "$b"
 24: Variable (80 to 82) "$c"
-25: List(ListId(0)) (70 to 82)
-26: Block(BlockId(0)) (68 to 85)
+25: List(ListId(0)) (70 to 82) - sub_nodes: 22,23,24
+26: Block(BlockId(0)) (68 to 85) - sub_nodes: 25
 27: Def { name: NodeId(8), type_params: None, params: NodeId(21), in_out_types: None, block: NodeId(26), env: false, wrapped: false } (24 to 85)
 28: Name (86 to 94) "existing"
 29: Name (95 to 98) "foo"
@@ -40,11 +39,11 @@ input_file: tests/calls.nu
 32: String (107 to 110) ""r""
 33: BinaryOp { lhs: NodeId(30), op: NodeId(31), rhs: NodeId(32) } (100 to 110)
 34: Int (112 to 113) "3"
-35: Call(CallId(1)) (95 to 113)
+35: Call(CallId(1)) (95 to 113) - sub_nodes: 28,29,33,34
 36: Name (115 to 128) "foo/bar/spam
 "
-37: Call(CallId(2)) (127 to 127)
-38: Block(BlockId(1)) (0 to 128)
+37: Call(CallId(2)) (127 to 127) - sub_nodes: 36
+38: Block(BlockId(1)) (0 to 128) - sub_nodes: 7,27,35,37
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(38)
       decls: [ existing: NodeId(8) ]

--- a/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@calls_invalid.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/calls_invalid.nu
 ---
@@ -10,17 +9,17 @@ input_file: tests/calls_invalid.nu
 2: Name (13 to 16) "int"
 3: Type { name: NodeId(2), args: None, optional: false } (13 to 16)
 4: Param { name: NodeId(1), ty: Some(NodeId(3)) } (10 to 16)
-5: Params(ParamsId(0)) (8 to 18)
-6: Block(BlockId(0)) (19 to 21)
+5: Params(ParamsId(0)) (8 to 18) - sub_nodes: 4
+6: Block(BlockId(0)) (19 to 21) - sub_nodes is empty
 7: Def { name: NodeId(0), type_params: None, params: NodeId(5), in_out_types: None, block: NodeId(6), env: false, wrapped: false } (0 to 21)
 8: Name (22 to 25) "foo"
 9: Int (26 to 27) "1"
 10: Int (28 to 29) "2"
-11: Call(CallId(0)) (26 to 29)
+11: Call(CallId(0)) (26 to 29) - sub_nodes: 8,9,10
 12: Name (30 to 33) "foo"
 13: String (34 to 42) ""string""
-14: Call(CallId(1)) (34 to 42)
-15: Block(BlockId(1)) (0 to 43)
+14: Call(CallId(1)) (34 to 42) - sub_nodes: 12,13
+15: Block(BlockId(1)) (0 to 43) - sub_nodes: 7,11,14
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(15)
       decls: [ foo: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/closure.nu
 ---
@@ -9,15 +8,15 @@ input_file: tests/closure.nu
 1: Param { name: NodeId(0), ty: None } (3 to 4)
 2: Name (6 to 7) "b"
 3: Param { name: NodeId(2), ty: None } (6 to 7)
-4: Params(ParamsId(0)) (2 to 8)
+4: Params(ParamsId(0)) (2 to 8) - sub_nodes: 1,3
 5: Variable (9 to 11) "$a"
 6: Plus (12 to 13)
 7: Variable (14 to 16) "$b"
 8: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(7) } (9 to 16)
-9: Block(BlockId(0)) (9 to 16)
+9: Block(BlockId(0)) (9 to 16) - sub_nodes: 8
 10: Closure { params: Some(NodeId(4)), block: NodeId(9) } (0 to 17)
 11: Variable (18 to 20) "$a"
-12: Block(BlockId(1)) (0 to 42)
+12: Block(BlockId(1)) (0 to 42) - sub_nodes: 10,11
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(12) (empty)
 1: Frame Scope, node_id: NodeId(9)

--- a/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
@@ -2,19 +2,19 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/closure2.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 6) "$a"
 1: Plus (7 to 8)
 2: Variable (9 to 11) "$b"
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (4 to 11)
-4: Block(BlockId(0)) (4 to 12)
+4: Block(BlockId(0)) (4 to 12) - sub_nodes: 3
 5: Closure { params: None, block: NodeId(4) } (0 to 13)
-6: Block(BlockId(1)) (0 to 14)
+6: Block(BlockId(1)) (0 to 14) - sub_nodes: 5
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6) (empty)
 1: Frame Scope, node_id: NodeId(4) (empty)
 ==== SCOPE ERRORS ====
 Error (NodeId 0): variable `a` not found
 Error (NodeId 2): variable `b` not found
+

--- a/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure3.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/closure3.nu
 ---
@@ -14,7 +13,7 @@ input_file: tests/closure3.nu
 6: Name (27 to 30) "int"
 7: Type { name: NodeId(6), args: None, optional: false } (27 to 30)
 8: Param { name: NodeId(5), ty: Some(NodeId(7)) } (24 to 30)
-9: Params(ParamsId(0)) (15 to 31)
+9: Params(ParamsId(0)) (15 to 31) - sub_nodes: 4,8
 10: Variable (32 to 34) "$a"
 11: Plus (35 to 36)
 12: Variable (37 to 39) "$b"
@@ -22,13 +21,13 @@ input_file: tests/closure3.nu
 14: Int (42 to 43) "5"
 15: BinaryOp { lhs: NodeId(10), op: NodeId(11), rhs: NodeId(12) } (32 to 39)
 16: BinaryOp { lhs: NodeId(15), op: NodeId(13), rhs: NodeId(14) } (32 to 43)
-17: Block(BlockId(0)) (32 to 43)
+17: Block(BlockId(0)) (32 to 43) - sub_nodes: 16
 18: Closure { params: Some(NodeId(9)), block: NodeId(17) } (14 to 44)
 19: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(18), is_mutable: false } (0 to 44)
 20: Name (46 to 52) "filter"
 21: Variable (53 to 61) "$closure"
-22: Call(CallId(0)) (53 to 61)
-23: Block(BlockId(1)) (0 to 62)
+22: Call(CallId(0)) (53 to 61) - sub_nodes: 20,21
+23: Block(BlockId(1)) (0 to 62) - sub_nodes: 19,22
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(23)
   variables: [ closure: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def.nu
 ---
@@ -17,9 +16,9 @@ input_file: tests/def.nu
 9: Name (27 to 31) "list"
 10: Name (32 to 35) "int"
 11: Type { name: NodeId(10), args: None, optional: false } (32 to 35)
-12: TypeArgs(TypeArgsId(0)) (31 to 36)
+12: TypeArgs(TypeArgsId(0)) (31 to 36) - sub_nodes: 11
 13: Type { name: NodeId(9), args: Some(NodeId(12)), optional: false } (27 to 31)
-14: TypeArgs(TypeArgsId(1)) (26 to 37)
+14: TypeArgs(TypeArgsId(1)) (26 to 37) - sub_nodes: 13
 15: Type { name: NodeId(8), args: Some(NodeId(14)), optional: false } (22 to 26)
 16: Param { name: NodeId(7), ty: Some(NodeId(15)) } (19 to 26)
 17: Name (39 to 40) "z"
@@ -30,18 +29,18 @@ input_file: tests/def.nu
 22: Name (55 to 58) "int"
 23: Type { name: NodeId(22), args: None, optional: false } (55 to 58)
 24: Param { name: NodeId(21), ty: Some(NodeId(23)) } (52 to 58)
-25: Params(ParamsId(0)) (48 to 59)
+25: Params(ParamsId(0)) (48 to 59) - sub_nodes: 20,24
 26: RecordType { fields: NodeId(25), optional: false } (42 to 60)
 27: Param { name: NodeId(17), ty: Some(NodeId(26)) } (39 to 60)
-28: Params(ParamsId(1)) (8 to 61)
+28: Params(ParamsId(1)) (8 to 61) - sub_nodes: 2,6,16,27
 29: Variable (66 to 68) "$w"
 30: Variable (69 to 71) "$x"
 31: Variable (73 to 75) "$y"
 32: Variable (77 to 79) "$z"
-33: List(ListId(0)) (64 to 80)
-34: Block(BlockId(0)) (62 to 83)
+33: List(ListId(0)) (64 to 80) - sub_nodes: 29,30,31,32
+34: Block(BlockId(0)) (62 to 83) - sub_nodes: 33
 35: Def { name: NodeId(0), type_params: None, params: NodeId(28), in_out_types: None, block: NodeId(34), env: false, wrapped: false } (0 to 83)
-36: Block(BlockId(1)) (0 to 83)
+36: Block(BlockId(1)) (0 to 83) - sub_nodes: 35
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(36)
       decls: [ foo: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_return_type.nu.snap
@@ -1,32 +1,31 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def_return_type.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 7) "foo"
-1: Params(ParamsId(0)) (8 to 11)
+1: Params(ParamsId(0)) (8 to 11) - sub_nodes is empty
 2: Name (14 to 21) "nothing"
 3: Type { name: NodeId(2), args: None, optional: false } (14 to 21)
 4: Name (25 to 29) "list"
 5: Name (30 to 33) "any"
 6: Type { name: NodeId(5), args: None, optional: false } (30 to 33)
-7: TypeArgs(TypeArgsId(0)) (29 to 34)
+7: TypeArgs(TypeArgsId(0)) (29 to 34) - sub_nodes: 6
 8: Type { name: NodeId(4), args: Some(NodeId(7)), optional: false } (25 to 29)
 9: InOutType(NodeId(3), NodeId(8)) (14 to 35)
-10: InOutTypes(InOutTypesId(0)) (14 to 35)
-11: List(ListId(0)) (37 to 38)
-12: Block(BlockId(0)) (35 to 41)
+10: InOutTypes(InOutTypesId(0)) (14 to 35) - sub_nodes: 9
+11: List(ListId(0)) (37 to 38) - sub_nodes is empty
+12: Block(BlockId(0)) (35 to 41) - sub_nodes: 11
 13: Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: Some(NodeId(10)), block: NodeId(12), env: false, wrapped: false } (0 to 41)
 14: Name (46 to 49) "bar"
-15: Params(ParamsId(1)) (50 to 53)
+15: Params(ParamsId(1)) (50 to 53) - sub_nodes is empty
 16: Name (58 to 64) "string"
 17: Type { name: NodeId(16), args: None, optional: false } (58 to 64)
 18: Name (68 to 72) "list"
 19: Name (73 to 79) "string"
 20: Type { name: NodeId(19), args: None, optional: false } (73 to 79)
-21: TypeArgs(TypeArgsId(1)) (72 to 80)
+21: TypeArgs(TypeArgsId(1)) (72 to 80) - sub_nodes: 20
 22: Type { name: NodeId(18), args: Some(NodeId(21)), optional: false } (68 to 72)
 23: InOutType(NodeId(17), NodeId(22)) (58 to 80)
 24: Name (82 to 85) "int"
@@ -34,14 +33,14 @@ input_file: tests/def_return_type.nu
 26: Name (89 to 93) "list"
 27: Name (94 to 97) "int"
 28: Type { name: NodeId(27), args: None, optional: false } (94 to 97)
-29: TypeArgs(TypeArgsId(2)) (93 to 98)
+29: TypeArgs(TypeArgsId(2)) (93 to 98) - sub_nodes: 28
 30: Type { name: NodeId(26), args: Some(NodeId(29)), optional: false } (89 to 93)
 31: InOutType(NodeId(25), NodeId(30)) (82 to 99)
-32: InOutTypes(InOutTypesId(1)) (56 to 101)
-33: List(ListId(1)) (103 to 104)
-34: Block(BlockId(1)) (101 to 107)
+32: InOutTypes(InOutTypesId(1)) (56 to 101) - sub_nodes: 23,31
+33: List(ListId(1)) (103 to 104) - sub_nodes is empty
+34: Block(BlockId(1)) (101 to 107) - sub_nodes: 33
 35: Def { name: NodeId(14), type_params: None, params: NodeId(15), in_out_types: Some(NodeId(32)), block: NodeId(34), env: false, wrapped: false } (42 to 107)
-36: Block(BlockId(2)) (0 to 108)
+36: Block(BlockId(2)) (0 to 108) - sub_nodes: 13,35
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(36)
       decls: [ bar: NodeId(14), foo: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@def_with_flags.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@def_with_flags.nu.snap
@@ -1,26 +1,25 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/def_with_flags.nu
 ---
 ==== COMPILER ====
 0: Name (10 to 13) "foo"
-1: Params(ParamsId(0)) (14 to 17)
+1: Params(ParamsId(0)) (14 to 17) - sub_nodes is empty
 2: String (20 to 25) ""foo""
-3: Block(BlockId(0)) (18 to 27)
+3: Block(BlockId(0)) (18 to 27) - sub_nodes: 2
 4: Def { name: NodeId(0), type_params: None, params: NodeId(1), in_out_types: None, block: NodeId(3), env: true, wrapped: false } (0 to 27)
 5: Name (42 to 46) "foo2"
-6: Params(ParamsId(1)) (47 to 50)
+6: Params(ParamsId(1)) (47 to 50) - sub_nodes is empty
 7: String (53 to 59) ""foo2""
-8: Block(BlockId(1)) (51 to 61)
+8: Block(BlockId(1)) (51 to 61) - sub_nodes: 7
 9: Def { name: NodeId(5), type_params: None, params: NodeId(6), in_out_types: None, block: NodeId(8), env: false, wrapped: true } (28 to 61)
 10: Name (82 to 86) "foo3"
-11: Params(ParamsId(2)) (87 to 90)
+11: Params(ParamsId(2)) (87 to 90) - sub_nodes is empty
 12: String (93 to 99) ""foo3""
-13: Block(BlockId(2)) (91 to 101)
+13: Block(BlockId(2)) (91 to 101) - sub_nodes: 12
 14: Def { name: NodeId(10), type_params: None, params: NodeId(11), in_out_types: None, block: NodeId(13), env: true, wrapped: true } (62 to 101)
-15: Block(BlockId(3)) (0 to 102)
+15: Block(BlockId(3)) (0 to 102) - sub_nodes: 4,9,14
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(15)
       decls: [ foo2: NodeId(5), foo3: NodeId(10), foo: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@extern.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@extern.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/extern.nu
 ---
@@ -10,9 +9,9 @@ input_file: tests/extern.nu
 2: Name (19 to 25) "string"
 3: Type { name: NodeId(2), args: None, optional: false } (19 to 25)
 4: Param { name: NodeId(1), ty: Some(NodeId(3)) } (13 to 25)
-5: Params(ParamsId(0)) (12 to 26)
+5: Params(ParamsId(0)) (12 to 26) - sub_nodes: 4
 6: Extern { name: NodeId(0), params: NodeId(5) } (0 to 26)
-7: Block(BlockId(0)) (0 to 27)
+7: Block(BlockId(0)) (0 to 27) - sub_nodes: 6
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(7) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/for.nu
 ---
@@ -12,7 +11,7 @@ input_file: tests/for.nu
 4: Int (20 to 21) "1"
 5: Int (22 to 23) "2"
 6: Int (24 to 25) "3"
-7: List(ListId(0)) (19 to 25)
+7: List(ListId(0)) (19 to 25) - sub_nodes: 4,5,6
 8: Variable (33 to 35) "$x"
 9: Assignment (36 to 37)
 10: Variable (38 to 40) "$x"
@@ -20,13 +19,13 @@ input_file: tests/for.nu
 12: Variable (43 to 45) "$i"
 13: BinaryOp { lhs: NodeId(10), op: NodeId(11), rhs: NodeId(12) } (38 to 45)
 14: BinaryOp { lhs: NodeId(8), op: NodeId(9), rhs: NodeId(13) } (33 to 45)
-15: Block(BlockId(0)) (27 to 47)
+15: Block(BlockId(0)) (27 to 47) - sub_nodes: 14
 16: For { variable: NodeId(3), range: NodeId(7), block: NodeId(15) } (10 to 47)
 17: Variable (53 to 55) "$i"
 18: Int (60 to 61) "4"
 19: Int (62 to 63) "5"
 20: Int (64 to 65) "6"
-21: List(ListId(1)) (59 to 65)
+21: List(ListId(1)) (59 to 65) - sub_nodes: 18,19,20
 22: Variable (73 to 75) "$x"
 23: Assignment (76 to 77)
 24: Variable (78 to 80) "$x"
@@ -34,9 +33,9 @@ input_file: tests/for.nu
 26: Variable (83 to 85) "$i"
 27: BinaryOp { lhs: NodeId(24), op: NodeId(25), rhs: NodeId(26) } (78 to 85)
 28: BinaryOp { lhs: NodeId(22), op: NodeId(23), rhs: NodeId(27) } (73 to 85)
-29: Block(BlockId(1)) (67 to 87)
+29: Block(BlockId(1)) (67 to 87) - sub_nodes: 28
 30: For { variable: NodeId(17), range: NodeId(21), block: NodeId(29) } (49 to 87)
-31: Block(BlockId(2)) (0 to 88)
+31: Block(BlockId(2)) (0 to 88) - sub_nodes: 2,16,30
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(31)
   variables: [ x: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/for_break_continue.nu
 ---
@@ -12,20 +11,20 @@ input_file: tests/for_break_continue.nu
 4: Int (20 to 21) "1"
 5: Int (22 to 23) "2"
 6: Int (24 to 25) "3"
-7: List(ListId(0)) (19 to 25)
+7: List(ListId(0)) (19 to 25) - sub_nodes: 4,5,6
 8: Variable (36 to 38) "$x"
 9: GreaterThan (39 to 40)
 10: Int (41 to 42) "2"
 11: BinaryOp { lhs: NodeId(8), op: NodeId(9), rhs: NodeId(10) } (36 to 42)
 12: Break (53 to 58)
-13: Block(BlockId(0)) (43 to 64)
+13: Block(BlockId(0)) (43 to 64) - sub_nodes: 12
 14: If { condition: NodeId(11), then_block: NodeId(13), else_block: None } (33 to 64)
 15: Variable (73 to 75) "$i"
 16: LessThan (76 to 77)
 17: Int (78 to 79) "3"
 18: BinaryOp { lhs: NodeId(15), op: NodeId(16), rhs: NodeId(17) } (73 to 79)
 19: Continue (90 to 98)
-20: Block(BlockId(1)) (80 to 104)
+20: Block(BlockId(1)) (80 to 104) - sub_nodes: 19
 21: If { condition: NodeId(18), then_block: NodeId(20), else_block: None } (70 to 104)
 22: Variable (110 to 112) "$x"
 23: Assignment (113 to 114)
@@ -34,9 +33,9 @@ input_file: tests/for_break_continue.nu
 26: Variable (120 to 122) "$i"
 27: BinaryOp { lhs: NodeId(24), op: NodeId(25), rhs: NodeId(26) } (115 to 122)
 28: BinaryOp { lhs: NodeId(22), op: NodeId(23), rhs: NodeId(27) } (110 to 122)
-29: Block(BlockId(2)) (27 to 124)
+29: Block(BlockId(2)) (27 to 124) - sub_nodes: 14,21,28
 30: For { variable: NodeId(3), range: NodeId(7), block: NodeId(29) } (10 to 124)
-31: Block(BlockId(3)) (0 to 124)
+31: Block(BlockId(3)) (0 to 124) - sub_nodes: 2,30
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(31)
   variables: [ x: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/if_.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -13,18 +12,18 @@ snapshot_kind: text
 5: Int (21 to 24) "100"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 24)
 7: Int (31 to 32) "5"
-8: Block(BlockId(0)) (25 to 35)
+8: Block(BlockId(0)) (25 to 35) - sub_nodes: 7
 9: Variable (43 to 45) "$x"
 10: GreaterThan (46 to 47)
 11: Int (48 to 51) "200"
 12: BinaryOp { lhs: NodeId(9), op: NodeId(10), rhs: NodeId(11) } (43 to 51)
 13: Int (58 to 59) "6"
-14: Block(BlockId(1)) (52 to 62)
+14: Block(BlockId(1)) (52 to 62) - sub_nodes: 13
 15: Int (73 to 74) "7"
-16: Block(BlockId(2)) (67 to 76)
+16: Block(BlockId(2)) (67 to 76) - sub_nodes: 15
 17: If { condition: NodeId(12), then_block: NodeId(14), else_block: Some(NodeId(16)) } (40 to 76)
 18: If { condition: NodeId(6), then_block: NodeId(8), else_block: Some(NodeId(17)) } (13 to 76)
-19: Block(BlockId(3)) (0 to 77)
+19: Block(BlockId(3)) (0 to 77) - sub_nodes: 2,18
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(19)
   variables: [ x: NodeId(0) ]
@@ -57,3 +56,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@if_oneof.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_oneof.nu.snap
@@ -13,36 +13,36 @@ input_file: tests/if_oneof.nu
 6: Type { name: NodeId(5), args: None, optional: false } (26 to 32)
 7: Name (34 to 37) "int"
 8: Type { name: NodeId(7), args: None, optional: false } (34 to 37)
-9: TypeArgs(TypeArgsId(0)) (25 to 38)
+9: TypeArgs(TypeArgsId(0)) (25 to 38) - sub_nodes: 6,8
 10: Type { name: NodeId(4), args: Some(NodeId(9)), optional: false } (20 to 25)
 11: Variable (44 to 46) "$x"
 12: LessThan (47 to 48)
 13: Int (49 to 51) "50"
 14: BinaryOp { lhs: NodeId(11), op: NodeId(12), rhs: NodeId(13) } (44 to 51)
 15: String (56 to 61) ""foo""
-16: Block(BlockId(0)) (52 to 64)
+16: Block(BlockId(0)) (52 to 64) - sub_nodes: 15
 17: Int (73 to 76) "100"
-18: Block(BlockId(1)) (69 to 78)
+18: Block(BlockId(1)) (69 to 78) - sub_nodes: 17
 19: If { condition: NodeId(14), then_block: NodeId(16), else_block: Some(NodeId(18)) } (41 to 78)
 20: Let { variable_name: NodeId(3), ty: Some(NodeId(10)), initializer: NodeId(19), is_mutable: false } (13 to 78)
 21: Variable (118 to 119) "y"
 22: Name (121 to 126) "oneof"
 23: Name (127 to 130) "int"
 24: Type { name: NodeId(23), args: None, optional: false } (127 to 130)
-25: TypeArgs(TypeArgsId(1)) (126 to 131)
+25: TypeArgs(TypeArgsId(1)) (126 to 131) - sub_nodes: 24
 26: Type { name: NodeId(22), args: Some(NodeId(25)), optional: false } (121 to 126)
 27: Variable (137 to 139) "$x"
 28: LessThan (140 to 141)
 29: Int (142 to 144) "50"
 30: BinaryOp { lhs: NodeId(27), op: NodeId(28), rhs: NodeId(29) } (137 to 144)
 31: Int (149 to 152) "100"
-32: Block(BlockId(2)) (145 to 155)
+32: Block(BlockId(2)) (145 to 155) - sub_nodes: 31
 33: Int (164 to 166) "10"
-34: Block(BlockId(3)) (160 to 168)
+34: Block(BlockId(3)) (160 to 168) - sub_nodes: 33
 35: If { condition: NodeId(30), then_block: NodeId(32), else_block: Some(NodeId(34)) } (134 to 168)
 36: Let { variable_name: NodeId(21), ty: Some(NodeId(26)), initializer: NodeId(35), is_mutable: false } (114 to 168)
 37: Variable (170 to 172) "$z"
-38: Block(BlockId(4)) (0 to 173)
+38: Block(BlockId(4)) (0 to 173) - sub_nodes: 2,20,36,37
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(38)
   variables: [ x: NodeId(0), y: NodeId(21), z: NodeId(3) ]
@@ -95,3 +95,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_complex.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_complex.nu
 ---
@@ -8,7 +7,7 @@ input_file: tests/infer_complex.nu
 0: Name (4 to 5) "f"
 1: Name (6 to 7) "A"
 2: Name (9 to 10) "B"
-3: Params(ParamsId(0)) (5 to 11)
+3: Params(ParamsId(0)) (5 to 11) - sub_nodes: 1,2
 4: Name (14 to 15) "x"
 5: Name (17 to 23) "record"
 6: Name (24 to 25) "a"
@@ -19,7 +18,7 @@ input_file: tests/infer_complex.nu
 11: Name (33 to 34) "B"
 12: Type { name: NodeId(11), args: None, optional: false } (33 to 34)
 13: Param { name: NodeId(10), ty: Some(NodeId(12)) } (30 to 34)
-14: Params(ParamsId(1)) (23 to 35)
+14: Params(ParamsId(1)) (23 to 35) - sub_nodes: 9,13
 15: RecordType { fields: NodeId(14), optional: false } (17 to 35)
 16: Param { name: NodeId(4), ty: Some(NodeId(15)) } (14 to 35)
 17: Name (37 to 38) "y"
@@ -32,10 +31,10 @@ input_file: tests/infer_complex.nu
 24: Name (56 to 57) "B"
 25: Type { name: NodeId(24), args: None, optional: false } (56 to 57)
 26: Param { name: NodeId(23), ty: Some(NodeId(25)) } (53 to 57)
-27: Params(ParamsId(2)) (46 to 58)
+27: Params(ParamsId(2)) (46 to 58) - sub_nodes: 22,26
 28: RecordType { fields: NodeId(27), optional: false } (40 to 59)
 29: Param { name: NodeId(17), ty: Some(NodeId(28)) } (37 to 59)
-30: Params(ParamsId(3)) (12 to 60)
+30: Params(ParamsId(3)) (12 to 60) - sub_nodes: 16,29
 31: Name (63 to 70) "nothing"
 32: Type { name: NodeId(31), args: None, optional: false } (63 to 70)
 33: Name (74 to 80) "record"
@@ -47,33 +46,33 @@ input_file: tests/infer_complex.nu
 39: Name (90 to 91) "B"
 40: Type { name: NodeId(39), args: None, optional: false } (90 to 91)
 41: Param { name: NodeId(38), ty: Some(NodeId(40)) } (87 to 91)
-42: Params(ParamsId(4)) (80 to 92)
+42: Params(ParamsId(4)) (80 to 92) - sub_nodes: 37,41
 43: RecordType { fields: NodeId(42), optional: false } (74 to 93)
 44: InOutType(NodeId(32), NodeId(43)) (63 to 93)
-45: InOutTypes(InOutTypesId(0)) (63 to 93)
+45: InOutTypes(InOutTypesId(0)) (63 to 93) - sub_nodes: 44
 46: Variable (97 to 99) "$x"
-47: Block(BlockId(0)) (93 to 101)
+47: Block(BlockId(0)) (93 to 101) - sub_nodes: 46
 48: Def { name: NodeId(0), type_params: Some(NodeId(3)), params: NodeId(30), in_out_types: Some(NodeId(45)), block: NodeId(47), env: false, wrapped: false } (0 to 101)
 49: Name (106 to 116) "mysterious"
 50: Name (117 to 118) "T"
-51: Params(ParamsId(5)) (116 to 119)
+51: Params(ParamsId(5)) (116 to 119) - sub_nodes: 50
 52: Name (122 to 123) "x"
 53: Name (125 to 128) "int"
 54: Type { name: NodeId(53), args: None, optional: false } (125 to 128)
 55: Param { name: NodeId(52), ty: Some(NodeId(54)) } (122 to 128)
-56: Params(ParamsId(6)) (120 to 130)
+56: Params(ParamsId(6)) (120 to 130) - sub_nodes: 55
 57: Name (133 to 140) "nothing"
 58: Type { name: NodeId(57), args: None, optional: false } (133 to 140)
 59: Name (144 to 145) "T"
 60: Type { name: NodeId(59), args: None, optional: false } (144 to 145)
 61: InOutType(NodeId(58), NodeId(60)) (133 to 146)
-62: InOutTypes(InOutTypesId(1)) (133 to 146)
-63: Block(BlockId(1)) (146 to 148)
+62: InOutTypes(InOutTypesId(1)) (133 to 146) - sub_nodes: 61
+63: Block(BlockId(1)) (146 to 148) - sub_nodes is empty
 64: Def { name: NodeId(49), type_params: Some(NodeId(51)), params: NodeId(56), in_out_types: Some(NodeId(62)), block: NodeId(63), env: false, wrapped: false } (102 to 148)
 65: Variable (154 to 155) "m"
 66: Name (158 to 168) "mysterious"
 67: Int (169 to 170) "0"
-68: Call(CallId(0)) (169 to 170)
+68: Call(CallId(0)) (169 to 170) - sub_nodes: 66,67
 69: Let { variable_name: NodeId(65), ty: None, initializer: NodeId(68), is_mutable: false } (150 to 170)
 70: Variable (175 to 176) "a"
 71: Name (178 to 184) "record"
@@ -81,22 +80,22 @@ input_file: tests/infer_complex.nu
 73: Name (188 to 194) "number"
 74: Type { name: NodeId(73), args: None, optional: false } (188 to 194)
 75: Param { name: NodeId(72), ty: Some(NodeId(74)) } (185 to 194)
-76: Params(ParamsId(7)) (184 to 195)
+76: Params(ParamsId(7)) (184 to 195) - sub_nodes: 75
 77: RecordType { fields: NodeId(76), optional: false } (178 to 196)
 78: Name (198 to 199) "f"
 79: String (202 to 203) "a"
 80: Int (205 to 208) "123"
 81: String (210 to 211) "b"
 82: Variable (213 to 215) "$m"
-83: Record(RecordId(0)) (200 to 218)
+83: Record(RecordId(0)) (200 to 218) - sub_nodes: pairs: 79: 80,81: 82
 84: String (220 to 221) "a"
 85: Float (223 to 227) "12.3"
 86: String (229 to 230) "b"
 87: String (232 to 237) ""foo""
-88: Record(RecordId(1)) (218 to 239)
-89: Call(CallId(1)) (200 to 239)
+88: Record(RecordId(1)) (218 to 239) - sub_nodes: pairs: 84: 85,86: 87
+89: Call(CallId(1)) (200 to 239) - sub_nodes: 78,83,88
 90: Let { variable_name: NodeId(70), ty: Some(NodeId(77)), initializer: NodeId(89), is_mutable: false } (171 to 239)
-91: Block(BlockId(2)) (0 to 240)
+91: Block(BlockId(2)) (0 to 240) - sub_nodes: 48,64,69,90
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(91)
   variables: [ a: NodeId(70), m: NodeId(65) ]

--- a/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_generics.nu.snap
@@ -1,40 +1,39 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_generics.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 5) "f"
 1: Name (6 to 7) "T"
-2: Params(ParamsId(0)) (5 to 8)
+2: Params(ParamsId(0)) (5 to 8) - sub_nodes: 1
 3: Name (11 to 12) "x"
 4: Name (14 to 15) "T"
 5: Type { name: NodeId(4), args: None, optional: false } (14 to 15)
 6: Param { name: NodeId(3), ty: Some(NodeId(5)) } (11 to 15)
-7: Params(ParamsId(1)) (9 to 17)
+7: Params(ParamsId(1)) (9 to 17) - sub_nodes: 6
 8: Name (20 to 27) "nothing"
 9: Type { name: NodeId(8), args: None, optional: false } (20 to 27)
 10: Name (31 to 35) "list"
 11: Name (36 to 37) "T"
 12: Type { name: NodeId(11), args: None, optional: false } (36 to 37)
-13: TypeArgs(TypeArgsId(0)) (35 to 38)
+13: TypeArgs(TypeArgsId(0)) (35 to 38) - sub_nodes: 12
 14: Type { name: NodeId(10), args: Some(NodeId(13)), optional: false } (31 to 35)
 15: InOutType(NodeId(9), NodeId(14)) (20 to 39)
-16: InOutTypes(InOutTypesId(0)) (20 to 39)
+16: InOutTypes(InOutTypesId(0)) (20 to 39) - sub_nodes: 15
 17: Variable (47 to 48) "z"
 18: Name (50 to 51) "T"
 19: Type { name: NodeId(18), args: None, optional: false } (50 to 51)
 20: Variable (54 to 56) "$x"
 21: Let { variable_name: NodeId(17), ty: Some(NodeId(19)), initializer: NodeId(20), is_mutable: false } (43 to 56)
 22: Variable (60 to 62) "$z"
-23: List(ListId(0)) (59 to 62)
-24: Block(BlockId(0)) (39 to 65)
+23: List(ListId(0)) (59 to 62) - sub_nodes: 22
+24: Block(BlockId(0)) (39 to 65) - sub_nodes: 21,23
 25: Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(16)), block: NodeId(24), env: false, wrapped: false } (0 to 65)
 26: Name (67 to 68) "f"
 27: Int (69 to 70) "1"
-28: Call(CallId(0)) (69 to 70)
-29: Block(BlockId(1)) (0 to 71)
+28: Call(CallId(0)) (69 to 70) - sub_nodes: 26,27
+29: Block(BlockId(1)) (0 to 71) - sub_nodes: 25,28
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(29)
       decls: [ f: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@infer_plus.nu.snap
@@ -1,30 +1,29 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/infer_plus.nu
 ---
 ==== COMPILER ====
 0: Name (4 to 14) "mysterious"
 1: Name (15 to 16) "T"
-2: Params(ParamsId(0)) (14 to 17)
+2: Params(ParamsId(0)) (14 to 17) - sub_nodes: 1
 3: Name (20 to 21) "x"
 4: Name (23 to 26) "int"
 5: Type { name: NodeId(4), args: None, optional: false } (23 to 26)
 6: Param { name: NodeId(3), ty: Some(NodeId(5)) } (20 to 26)
-7: Params(ParamsId(1)) (18 to 28)
+7: Params(ParamsId(1)) (18 to 28) - sub_nodes: 6
 8: Name (31 to 38) "nothing"
 9: Type { name: NodeId(8), args: None, optional: false } (31 to 38)
 10: Name (42 to 43) "T"
 11: Type { name: NodeId(10), args: None, optional: false } (42 to 43)
 12: InOutType(NodeId(9), NodeId(11)) (31 to 44)
-13: InOutTypes(InOutTypesId(0)) (31 to 44)
-14: Block(BlockId(0)) (44 to 46)
+13: InOutTypes(InOutTypesId(0)) (31 to 44) - sub_nodes: 12
+14: Block(BlockId(0)) (44 to 46) - sub_nodes is empty
 15: Def { name: NodeId(0), type_params: Some(NodeId(2)), params: NodeId(7), in_out_types: Some(NodeId(13)), block: NodeId(14), env: false, wrapped: false } (0 to 46)
 16: Variable (52 to 53) "m"
 17: Name (56 to 66) "mysterious"
 18: Int (67 to 68) "0"
-19: Call(CallId(0)) (67 to 68)
+19: Call(CallId(0)) (67 to 68) - sub_nodes: 17,18
 20: Let { variable_name: NodeId(16), ty: None, initializer: NodeId(19), is_mutable: false } (48 to 68)
 21: Variable (70 to 72) "$m"
 22: Plus (73 to 74)
@@ -34,7 +33,7 @@ input_file: tests/infer_plus.nu
 26: Plus (84 to 85)
 27: Int (86 to 89) "123"
 28: BinaryOp { lhs: NodeId(25), op: NodeId(26), rhs: NodeId(27) } (81 to 89)
-29: Block(BlockId(1)) (0 to 90)
+29: Block(BlockId(1)) (0 to 90) - sub_nodes: 15,20,24,28
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(29)
   variables: [ m: NodeId(16) ]

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_if.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_if.nu.snap
@@ -6,11 +6,11 @@ input_file: tests/invalid_if.nu
 ==== COMPILER ====
 0: Int (3 to 4) "1"
 1: Int (9 to 10) "4"
-2: Block(BlockId(0)) (5 to 13)
+2: Block(BlockId(0)) (5 to 13) - sub_nodes: 1
 3: Int (22 to 23) "3"
-4: Block(BlockId(1)) (18 to 25)
+4: Block(BlockId(1)) (18 to 25) - sub_nodes: 3
 5: If { condition: NodeId(0), then_block: NodeId(2), else_block: Some(NodeId(4)) } (0 to 25)
-6: Block(BlockId(2)) (0 to 26)
+6: Block(BlockId(2)) (0 to 26) - sub_nodes: 5
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6) (empty)
 1: Frame Scope, node_id: NodeId(2) (empty)
@@ -30,3 +30,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 5): node If { condition: NodeId(0), then_block: NodeId(2), else_block: Some(NodeId(4)) } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
@@ -2,12 +2,12 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/invalid_range.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (0 to 1) "1"
 1: Garbage (2 to 4)
 2: Int (5 to 6) "2"
-3: Block(BlockId(0)) (0 to 7)
+3: Block(BlockId(0)) (0 to 7) - sub_nodes: 0,1,2
 ==== COMPILER ERRORS ====
 Error (NodeId 1): incomplete expression
+

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/invalid_record.nu
 ---
@@ -10,8 +9,8 @@ input_file: tests/invalid_record.nu
 2: String (9 to 10) "b"
 3: Garbage (11 to 12)
 4: Garbage (13 to 13)
-5: Record(RecordId(0)) (0 to 0)
-6: Block(BlockId(0)) (0 to 13)
+5: Record(RecordId(0)) (0 to 0) - sub_nodes: pairs: 0: 1,2: 4
+6: Block(BlockId(0)) (0 to 13) - sub_nodes: 5
 ==== COMPILER ERRORS ====
 Error (NodeId 3): expected: colon ':'
 Error (NodeId 4): incomplete expression

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_types.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/invalid_types.nu
 ---
@@ -12,24 +11,24 @@ input_file: tests/invalid_types.nu
 4: Type { name: NodeId(3), args: None, optional: false } (17 to 20)
 5: Name (22 to 28) "string"
 6: Type { name: NodeId(5), args: None, optional: false } (22 to 28)
-7: TypeArgs(TypeArgsId(0)) (16 to 29)
+7: TypeArgs(TypeArgsId(0)) (16 to 29) - sub_nodes: 4,6
 8: Type { name: NodeId(2), args: Some(NodeId(7)), optional: false } (12 to 16)
 9: Param { name: NodeId(1), ty: Some(NodeId(8)) } (9 to 16)
-10: Params(ParamsId(0)) (8 to 30)
+10: Params(ParamsId(0)) (8 to 30) - sub_nodes: 9
 11: Variable (33 to 35) "$x"
-12: Block(BlockId(0)) (31 to 37)
+12: Block(BlockId(0)) (31 to 37) - sub_nodes: 11
 13: Def { name: NodeId(0), type_params: None, params: NodeId(10), in_out_types: None, block: NodeId(12), env: false, wrapped: false } (0 to 37)
 14: Name (42 to 45) "bar"
 15: Name (47 to 48) "y"
 16: Name (50 to 54) "list"
-17: TypeArgs(TypeArgsId(1)) (54 to 56)
+17: TypeArgs(TypeArgsId(1)) (54 to 56) - sub_nodes is empty
 18: Type { name: NodeId(16), args: Some(NodeId(17)), optional: false } (50 to 54)
 19: Param { name: NodeId(15), ty: Some(NodeId(18)) } (47 to 54)
-20: Params(ParamsId(1)) (46 to 57)
+20: Params(ParamsId(1)) (46 to 57) - sub_nodes: 19
 21: Variable (60 to 62) "$y"
-22: Block(BlockId(1)) (58 to 64)
+22: Block(BlockId(1)) (58 to 64) - sub_nodes: 21
 23: Def { name: NodeId(14), type_params: None, params: NodeId(20), in_out_types: None, block: NodeId(22), env: false, wrapped: false } (38 to 64)
-24: Block(BlockId(2)) (0 to 65)
+24: Block(BlockId(2)) (0 to 65) - sub_nodes: 13,23
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(24)
       decls: [ bar: NodeId(14), foo: NodeId(0) ]

--- a/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/let_.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -12,10 +11,10 @@ snapshot_kind: text
 4: Variable (21 to 22) "x"
 5: Int (25 to 28) "123"
 6: Int (31 to 34) "456"
-7: Pipeline(PipelineId(0)) (25 to 34)
+7: Pipeline(PipelineId(0)) (25 to 34) - sub_nodes: 5,6
 8: Let { variable_name: NodeId(4), ty: None, initializer: NodeId(7), is_mutable: false } (17 to 34)
 9: Variable (36 to 38) "$x"
-10: Block(BlockId(0)) (0 to 39)
+10: Block(BlockId(0)) (0 to 39) - sub_nodes: 2,3,8,9
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10)
   variables: [ x: NodeId(4) ]

--- a/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_mismatch.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/let_mismatch.nu
 ---
@@ -25,13 +24,13 @@ input_file: tests/let_mismatch.nu
 17: Name (99 to 103) "list"
 18: Name (104 to 107) "int"
 19: Type { name: NodeId(18), args: None, optional: false } (104 to 107)
-20: TypeArgs(TypeArgsId(0)) (103 to 108)
+20: TypeArgs(TypeArgsId(0)) (103 to 108) - sub_nodes: 19
 21: Type { name: NodeId(17), args: Some(NodeId(20)), optional: false } (99 to 103)
-22: TypeArgs(TypeArgsId(1)) (98 to 109)
+22: TypeArgs(TypeArgsId(1)) (98 to 109) - sub_nodes: 21
 23: Type { name: NodeId(16), args: Some(NodeId(22)), optional: false } (94 to 98)
 24: String (116 to 119) "'a'"
-25: List(ListId(0)) (114 to 120)
-26: List(ListId(1)) (112 to 122)
+25: List(ListId(0)) (114 to 120) - sub_nodes: 24
+26: List(ListId(1)) (112 to 122) - sub_nodes: 25
 27: Let { variable_name: NodeId(15), ty: Some(NodeId(23)), initializer: NodeId(26), is_mutable: false } (87 to 122)
 28: Variable (128 to 129) "v"
 29: Name (131 to 137) "record"
@@ -39,13 +38,13 @@ input_file: tests/let_mismatch.nu
 31: Name (141 to 144) "int"
 32: Type { name: NodeId(31), args: None, optional: false } (141 to 144)
 33: Param { name: NodeId(30), ty: Some(NodeId(32)) } (138 to 144)
-34: Params(ParamsId(0)) (137 to 145)
+34: Params(ParamsId(0)) (137 to 145) - sub_nodes: 33
 35: RecordType { fields: NodeId(34), optional: false } (131 to 146)
 36: String (149 to 150) "a"
 37: String (152 to 157) ""foo""
-38: Record(RecordId(0)) (148 to 158)
+38: Record(RecordId(0)) (148 to 158) - sub_nodes: pairs: 36: 37
 39: Let { variable_name: NodeId(28), ty: Some(NodeId(35)), initializer: NodeId(38), is_mutable: false } (124 to 158)
-40: Block(BlockId(0)) (0 to 159)
+40: Block(BlockId(0)) (0 to 159) - sub_nodes: 4,9,14,27,39
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(40)
   variables: [ v: NodeId(28), w: NodeId(15), x: NodeId(0), y: NodeId(5), z: NodeId(10) ]

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/list.nu
 ---
@@ -8,24 +7,24 @@ input_file: tests/list.nu
 0: Int (1 to 2) "1"
 1: Int (4 to 5) "2"
 2: Int (7 to 8) "3"
-3: List(ListId(0)) (0 to 8)
+3: List(ListId(0)) (0 to 8) - sub_nodes: 0,1,2
 4: Int (11 to 12) "0"
 5: Int (13 to 14) "1"
 6: Int (15 to 16) "2"
-7: List(ListId(1)) (10 to 16)
+7: List(ListId(1)) (10 to 16) - sub_nodes: 4,5,6
 8: String (19 to 22) ""0""
 9: String (23 to 26) ""1""
 10: String (27 to 30) ""2""
-11: List(ListId(2)) (18 to 30)
+11: List(ListId(2)) (18 to 30) - sub_nodes: 8,9,10
 12: Int (33 to 34) "0"
 13: Int (35 to 36) "1"
 14: Float (37 to 40) "2.2"
-15: List(ListId(3)) (32 to 40)
+15: List(ListId(3)) (32 to 40) - sub_nodes: 12,13,14
 16: Int (43 to 44) "0"
 17: Int (45 to 46) "1"
 18: String (47 to 50) ""2""
-19: List(ListId(4)) (42 to 50)
-20: Block(BlockId(0)) (0 to 52)
+19: List(ListId(4)) (42 to 50) - sub_nodes: 16,17,18
+20: Block(BlockId(0)) (0 to 52) - sub_nodes: 3,7,11,15,19
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(20) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/literals.nu
 ---
@@ -10,8 +9,8 @@ input_file: tests/literals.nu
 2: Int (11 to 12) "1"
 3: String (13 to 16) "abc"
 4: String (17 to 22) ""foo""
-5: List(ListId(0)) (0 to 22)
-6: Block(BlockId(0)) (0 to 24)
+5: List(ListId(0)) (0 to 22) - sub_nodes: 0,1,2,3,4
+6: Block(BlockId(0)) (0 to 24) - sub_nodes: 5
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(6) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
@@ -12,15 +12,15 @@ input_file: tests/loop.nu
 5: Int (29 to 31) "10"
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (24 to 31)
 7: Break (42 to 47)
-8: Block(BlockId(0)) (32 to 53)
+8: Block(BlockId(0)) (32 to 53) - sub_nodes: 7
 9: If { condition: NodeId(6), then_block: NodeId(8), else_block: None } (21 to 53)
 10: Variable (59 to 61) "$x"
 11: AddAssignment (62 to 64)
 12: Int (65 to 66) "1"
 13: BinaryOp { lhs: NodeId(10), op: NodeId(11), rhs: NodeId(12) } (59 to 66)
-14: Block(BlockId(1)) (15 to 68)
+14: Block(BlockId(1)) (15 to 68) - sub_nodes: 9,13
 15: Loop { block: NodeId(14) } (10 to 68)
-16: Block(BlockId(2)) (0 to 68)
+16: Block(BlockId(2)) (0 to 68) - sub_nodes: 2,15
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(16)
   variables: [ x: NodeId(0) ]
@@ -49,3 +49,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@match.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@match.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/match.nu
 ---
@@ -20,15 +19,15 @@ input_file: tests/match.nu
 12: Plus (75 to 76)
 13: Variable (77 to 79) "$w"
 14: BinaryOp { lhs: NodeId(11), op: NodeId(12), rhs: NodeId(13) } (73 to 79)
-15: Block(BlockId(0)) (59 to 82)
+15: Block(BlockId(0)) (59 to 82) - sub_nodes: 10,14
 16: Closure { params: None, block: NodeId(15) } (53 to 83)
 17: Int (87 to 88) "3"
 18: Null (92 to 96)
 19: String (100 to 101) "_"
 20: Garbage (106 to 107)
-21: Match(MatchId(0)) (21 to 110)
+21: Match(MatchId(0)) (21 to 110) - sub_nodes: target: 4, arms: 5: 6,7: 16,17: 18,19: 20
 22: Let { variable_name: NodeId(3), ty: None, initializer: NodeId(21), is_mutable: false } (11 to 110)
-23: Block(BlockId(1)) (0 to 111)
+23: Block(BlockId(1)) (0 to 111) - sub_nodes: 2,22
 ==== COMPILER ERRORS ====
 Error (NodeId 20): use null instead of ()
 

--- a/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
@@ -2,14 +2,13 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/math.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (0 to 1) "3"
 1: Plus (2 to 3)
 2: Int (4 to 5) "4"
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 5)
-4: Block(BlockId(0)) (0 to 5)
+4: Block(BlockId(0)) (0 to 5) - sub_nodes: 3
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(4) (empty)
 ==== TYPES ====
@@ -25,3 +24,4 @@ file_count: 0
 1: LoadLiteral { dst: RegId(1), lit: Int(4) }
 2: BinaryOp { lhs_dst: RegId(0), op: Math(Plus), rhs: RegId(1) }
 3: Return { src: RegId(0) }
+

--- a/src/snapshots/new_nu_parser__test__node_output@math_precedence.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math_precedence.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/math_precedence.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (0 to 1) "1"
@@ -15,7 +14,7 @@ snapshot_kind: text
 7: BinaryOp { lhs: NodeId(2), op: NodeId(3), rhs: NodeId(4) } (4 to 9)
 8: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(7) } (0 to 9)
 9: BinaryOp { lhs: NodeId(8), op: NodeId(5), rhs: NodeId(6) } (0 to 13)
-10: Block(BlockId(0)) (0 to 13)
+10: Block(BlockId(0)) (0 to 13) - sub_nodes: 9
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10) (empty)
 ==== TYPES ====
@@ -41,3 +40,4 @@ file_count: 0
 5: LoadLiteral { dst: RegId(3), lit: Int(4) }
 6: BinaryOp { lhs_dst: RegId(0), op: Math(Plus), rhs: RegId(3) }
 7: Return { src: RegId(0) }
+

--- a/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/mut_.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -22,7 +21,7 @@ snapshot_kind: text
 14: Type { name: NodeId(13), args: None, optional: false } (39 to 42)
 15: Int (45 to 48) "123"
 16: Int (51 to 54) "344"
-17: Pipeline(PipelineId(0)) (45 to 54)
+17: Pipeline(PipelineId(0)) (45 to 54) - sub_nodes: 15,16
 18: Let { variable_name: NodeId(12), ty: Some(NodeId(14)), initializer: NodeId(17), is_mutable: true } (32 to 54)
 19: Variable (56 to 58) "$y"
 20: Assignment (59 to 60)
@@ -31,7 +30,7 @@ snapshot_kind: text
 23: Int (65 to 66) "1"
 24: BinaryOp { lhs: NodeId(21), op: NodeId(22), rhs: NodeId(23) } (61 to 66)
 25: BinaryOp { lhs: NodeId(19), op: NodeId(20), rhs: NodeId(24) } (56 to 66)
-26: Block(BlockId(0)) (0 to 68)
+26: Block(BlockId(0)) (0 to 68) - sub_nodes: 4,11,18,25
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(26)
   variables: [ x: NodeId(0), y: NodeId(12) ]

--- a/src/snapshots/new_nu_parser__test__node_output@pipeline.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@pipeline.nu.snap
@@ -2,18 +2,17 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/pipeline.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Int (0 to 1) "1"
 1: Int (4 to 5) "3"
 2: Int (8 to 9) "5"
-3: Pipeline(PipelineId(0)) (0 to 9)
+3: Pipeline(PipelineId(0)) (0 to 9) - sub_nodes: 0,1,2
 4: Int (42 to 43) "1"
 5: Int (46 to 47) "2"
 6: Int (50 to 51) "3"
-7: Pipeline(PipelineId(1)) (42 to 51)
-8: Block(BlockId(0)) (0 to 52)
+7: Pipeline(PipelineId(1)) (42 to 51) - sub_nodes: 4,5,6
+8: Block(BlockId(0)) (0 to 52) - sub_nodes: 3,7
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(8) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record.nu
 ---
@@ -9,8 +8,8 @@ input_file: tests/record.nu
 1: Int (4 to 5) "1"
 2: String (7 to 8) "b"
 3: Int (10 to 11) "2"
-4: Record(RecordId(0)) (0 to 12)
-5: Block(BlockId(0)) (0 to 13)
+4: Record(RecordId(0)) (0 to 12) - sub_nodes: pairs: 0: 1,2: 3
+5: Block(BlockId(0)) (0 to 13) - sub_nodes: 4
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record2.nu
 ---
@@ -9,8 +8,8 @@ input_file: tests/record2.nu
 1: Int (6 to 7) "1"
 2: String (9 to 12) ""b""
 3: Int (14 to 15) "2"
-4: Record(RecordId(0)) (0 to 16)
-5: Block(BlockId(0)) (0 to 17)
+4: Record(RecordId(0)) (0 to 16) - sub_nodes: pairs: 0: 1,2: 3
+5: Block(BlockId(0)) (0 to 17) - sub_nodes: 4
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/record3.nu
 ---
@@ -9,8 +8,8 @@ input_file: tests/record3.nu
 1: Int (5 to 6) "1"
 2: String (9 to 10) "b"
 3: Int (12 to 13) "2"
-4: Record(RecordId(0)) (0 to 16)
-5: Block(BlockId(0)) (0 to 17)
+4: Record(RecordId(0)) (0 to 16) - sub_nodes: pairs: 0: 1,2: 3
+5: Block(BlockId(0)) (0 to 17) - sub_nodes: 4
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(5) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/reparse.nu
 ---
@@ -8,17 +7,17 @@ input_file: tests/reparse.nu
 0: Variable (4 to 5) "x"
 1: Name (10 to 11) "a"
 2: Param { name: NodeId(1), ty: None } (10 to 11)
-3: Params(ParamsId(0)) (9 to 12)
+3: Params(ParamsId(0)) (9 to 12) - sub_nodes: 2
 4: Variable (13 to 15) "$a"
-5: Block(BlockId(0)) (13 to 16)
+5: Block(BlockId(0)) (13 to 16) - sub_nodes: 4
 6: Closure { params: Some(NodeId(3)), block: NodeId(5) } (8 to 17)
 7: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(6), is_mutable: false } (0 to 17)
 8: Variable (22 to 23) "y"
 9: String (28 to 29) "a"
 10: String (31 to 32) "b"
-11: Record(RecordId(0)) (26 to 34)
+11: Record(RecordId(0)) (26 to 34) - sub_nodes: pairs: 9: 10
 12: Let { variable_name: NodeId(8), ty: None, initializer: NodeId(11), is_mutable: false } (18 to 34)
-13: Block(BlockId(1)) (0 to 34)
+13: Block(BlockId(1)) (0 to 34) - sub_nodes: 7,12
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(13)
   variables: [ x: NodeId(0), y: NodeId(8) ]

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -2,12 +2,11 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/string.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (0 to 13) ""hello world""
 1: String (14 to 27) "'hello world'"
-2: Block(BlockId(0)) (0 to 27)
+2: Block(BlockId(0)) (0 to 27) - sub_nodes: 0,1
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(2) (empty)
 ==== TYPES ====
@@ -19,3 +18,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 0): node String not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
@@ -2,14 +2,13 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/string_operation.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: String (0 to 5) ""abc""
 1: Plus (6 to 7)
 2: String (8 to 13) ""def""
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 13)
-4: Block(BlockId(0)) (0 to 13)
+4: Block(BlockId(0)) (0 to 13) - sub_nodes: 3
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(4) (empty)
 ==== TYPES ====
@@ -23,3 +22,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 0): node String not suported yet
+

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -1,21 +1,20 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/table.nu
 ---
 ==== COMPILER ====
 0: String (7 to 10) ""a""
 1: String (12 to 15) ""b""
-2: List(ListId(0)) (6 to 15)
+2: List(ListId(0)) (6 to 15) - sub_nodes: 0,1
 3: Int (24 to 25) "1"
 4: Int (27 to 28) "2"
-5: List(ListId(1)) (23 to 28)
+5: List(ListId(1)) (23 to 28) - sub_nodes: 3,4
 6: Int (35 to 36) "3"
 7: Int (38 to 39) "4"
-8: List(ListId(2)) (34 to 39)
-9: Table(TableId(0)) (0 to 41)
-10: Block(BlockId(0)) (0 to 42)
+8: List(ListId(2)) (34 to 39) - sub_nodes: 6,7
+9: Table(TableId(0)) (0 to 41) - sub_nodes: header: 2, rows: 5,8
+10: Block(BlockId(0)) (0 to 42) - sub_nodes: 9
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -1,21 +1,20 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/table2.nu
 ---
 ==== COMPILER ====
 0: String (7 to 8) "a"
 1: String (10 to 11) "b"
-2: List(ListId(0)) (6 to 11)
+2: List(ListId(0)) (6 to 11) - sub_nodes: 0,1
 3: Int (20 to 21) "1"
 4: Int (23 to 24) "2"
-5: List(ListId(1)) (19 to 24)
+5: List(ListId(1)) (19 to 24) - sub_nodes: 3,4
 6: Int (31 to 32) "3"
 7: Int (34 to 35) "4"
-8: List(ListId(2)) (30 to 35)
-9: Table(TableId(0)) (0 to 37)
-10: Block(BlockId(0)) (0 to 38)
+8: List(ListId(2)) (30 to 35) - sub_nodes: 6,7
+9: Table(TableId(0)) (0 to 37) - sub_nodes: header: 2, rows: 5,8
+10: Block(BlockId(0)) (0 to 38) - sub_nodes: 9
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(10) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@try.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@try.nu.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 77
 expression: evaluate_example(path)
 input_file: tests/try.nu
 ---
@@ -9,41 +8,41 @@ input_file: tests/try.nu
 1: Divide (12 to 13)
 2: Int (14 to 15) "0"
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (10 to 15)
-4: Block(BlockId(0)) (4 to 17)
+4: Block(BlockId(0)) (4 to 17) - sub_nodes: 3
 5: Try { try_block: NodeId(4), catch_block: None, finally_block: None } (0 to 17)
 6: Int (29 to 30) "1"
 7: Divide (31 to 32)
 8: Int (33 to 34) "0"
 9: BinaryOp { lhs: NodeId(6), op: NodeId(7), rhs: NodeId(8) } (29 to 34)
-10: Block(BlockId(1)) (23 to 37)
+10: Block(BlockId(1)) (23 to 37) - sub_nodes: 9
 11: Name (49 to 54) "print"
 12: String (55 to 59) ""aa""
-13: Call(CallId(0)) (55 to 59)
-14: Block(BlockId(2)) (43 to 61)
+13: Call(CallId(0)) (55 to 59) - sub_nodes: 11,12
+14: Block(BlockId(2)) (43 to 61) - sub_nodes: 13
 15: Try { try_block: NodeId(10), catch_block: Some(NodeId(14)), finally_block: None } (19 to 61)
 16: Int (73 to 74) "1"
 17: Divide (75 to 76)
 18: Int (77 to 78) "0"
 19: BinaryOp { lhs: NodeId(16), op: NodeId(17), rhs: NodeId(18) } (73 to 78)
-20: Block(BlockId(3)) (67 to 81)
+20: Block(BlockId(3)) (67 to 81) - sub_nodes: 19
 21: Name (95 to 100) "print"
 22: String (101 to 105) ""bb""
-23: Call(CallId(1)) (101 to 105)
-24: Block(BlockId(4)) (89 to 107)
+23: Call(CallId(1)) (101 to 105) - sub_nodes: 21,22
+24: Block(BlockId(4)) (89 to 107) - sub_nodes: 23
 25: Try { try_block: NodeId(20), catch_block: None, finally_block: Some(NodeId(24)) } (63 to 107)
 26: Int (119 to 120) "1"
 27: Divide (121 to 122)
 28: Int (123 to 124) "0"
 29: BinaryOp { lhs: NodeId(26), op: NodeId(27), rhs: NodeId(28) } (119 to 124)
-30: Block(BlockId(5)) (113 to 127)
+30: Block(BlockId(5)) (113 to 127) - sub_nodes: 29
 31: Int (139 to 141) "22"
-32: Block(BlockId(6)) (133 to 144)
+32: Block(BlockId(6)) (133 to 144) - sub_nodes: 31
 33: Name (158 to 163) "print"
 34: String (164 to 168) ""bb""
-35: Call(CallId(2)) (164 to 168)
-36: Block(BlockId(7)) (152 to 170)
+35: Call(CallId(2)) (164 to 168) - sub_nodes: 33,34
+36: Block(BlockId(7)) (152 to 170) - sub_nodes: 35
 37: Try { try_block: NodeId(30), catch_block: Some(NodeId(32)), finally_block: Some(NodeId(36)) } (109 to 170)
-38: Block(BlockId(8)) (0 to 172)
+38: Block(BlockId(8)) (0 to 172) - sub_nodes: 5,15,25,37
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(38) (empty)
 ==== TYPES ====

--- a/src/snapshots/new_nu_parser__test__node_output@variable_names.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@variable_names.nu.snap
@@ -2,13 +2,13 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/variable_names.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (0 to 4) "$abc"
 1: Variable (5 to 7) "$_"
 2: Variable (8 to 12) "$a_c"
 3: Garbage (14 to 17)
-4: Block(BlockId(0)) (0 to 18)
+4: Block(BlockId(0)) (0 to 18) - sub_nodes: 0,1,2,3
 ==== COMPILER ERRORS ====
 Error (NodeId 3): variable name must be a bareword
+

--- a/src/snapshots/new_nu_parser__test__node_output@while.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@while.nu.snap
@@ -2,7 +2,6 @@
 source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/while.nu
-snapshot_kind: text
 ---
 ==== COMPILER ====
 0: Variable (4 to 5) "x"
@@ -16,9 +15,9 @@ snapshot_kind: text
 8: AddAssignment (29 to 31)
 9: Int (32 to 33) "1"
 10: BinaryOp { lhs: NodeId(7), op: NodeId(8), rhs: NodeId(9) } (26 to 33)
-11: Block(BlockId(0)) (22 to 35)
+11: Block(BlockId(0)) (22 to 35) - sub_nodes: 10
 12: While { condition: NodeId(6), block: NodeId(11) } (10 to 35)
-13: Block(BlockId(1)) (0 to 36)
+13: Block(BlockId(1)) (0 to 36) - sub_nodes: 2,12
 ==== SCOPE ====
 0: Frame Scope, node_id: NodeId(13)
   variables: [ x: NodeId(0) ]
@@ -43,3 +42,4 @@ register_count: 0
 file_count: 0
 ==== IR ERRORS ====
 Error (NodeId 2): node Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } not suported yet
+


### PR DESCRIPTION
After this pr https://github.com/nushell/new-nu-parser/pull/70, some ast nodes' like `List` are saved behind a `Vec`, which makes it hard to see what it actually contains, for example:
```
# list.nu
[1,2,3]
```

The compilder session outputs:
```
0: Int (11 to 12) "1"
1: Int (13 to 14) "2"
2: Int (15 to 16) "3"
3: List(ListId(0)) (10 to 16) 
4: Block(BlockId(0)) (0 to 18)
```

This pr is going to make it outputs one level detail:
```
0: Int (11 to 12) "1"
1: Int (13 to 14) "2"
2: Int (15 to 16) "3"
3: List(ListId(0)) (10 to 16) - sub_nodes: 0,1,2
4: Block(BlockId(0)) (0 to 18) - sub_nodes: 3
```
So it's easy to see that List contains node 0, 1, 2. 

### Avoid too verbosing
If one node contains too many(7) sub nodes, it replaces some nodes with `...`, for example:
```
# list2.nu
[1,2,3,4,5,6,7,8]
```
It outputs:
```
0: Int (12 to 13) "1"
1: Int (14 to 15) "2"
2: Int (16 to 17) "3"
3: Int (18 to 19) "4"
4: Int (20 to 21) "5"
5: Int (22 to 23) "6"
6: Int (24 to 25) "7"
7: Int (26 to 27) "8"
8: List(ListId(0)) (11 to 27) - sub_nodes: 0,1,...,6,7
9: Block(BlockId(0)) (0 to 29) - sub_nodes: 8
```